### PR TITLE
fix: back off when reconnecting to a flapping SSE event stream

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -31,7 +31,44 @@ const (
 	// Token type URNs for RFC 8693 Token Exchange
 	tokenTypeJWT    = "urn:ietf:params:oauth:token-type:jwt"
 	tokenTypeAPIKey = "urn:obot:token-type:api-key"
+
+	// minStableStreamDuration is how long an SSE event stream must stay
+	// connected before it is considered healthy. A stream that closes sooner
+	// than this without delivering any message is treated as flapping and
+	// triggers reconnect backoff, so a server that repeatedly accepts and
+	// immediately drops the stream (or rejects it, e.g. with 429 Too Many
+	// Requests) cannot be hammered in a tight reconnect loop.
+	minStableStreamDuration = 5 * time.Second
+
+	// baseReconnectBackoff and maxReconnectBackoff bound the exponential
+	// backoff applied between reconnects to a flapping SSE stream.
+	baseReconnectBackoff = 500 * time.Millisecond
+	maxReconnectBackoff  = 30 * time.Second
 )
+
+// streamFlapped reports whether an SSE event stream that has just closed
+// should be treated as flapping: it delivered no messages and stayed connected
+// for less than minStableStreamDuration. Flapping streams are backed off before
+// the next reconnect; healthy ones reset the backoff.
+func streamFlapped(messagesReceived int, streamDuration time.Duration) bool {
+	return messagesReceived == 0 && streamDuration < minStableStreamDuration
+}
+
+// reconnectBackoff returns how long to wait before the Nth consecutive
+// reconnect to a flapping SSE stream, growing exponentially from
+// baseReconnectBackoff and capped at maxReconnectBackoff. A non-positive
+// count yields no delay.
+func reconnectBackoff(consecutiveFailures int) time.Duration {
+	if consecutiveFailures < 1 {
+		return 0
+	}
+	backoff := baseReconnectBackoff << (consecutiveFailures - 1)
+	// A non-positive result means the shift overflowed; cap it.
+	if backoff <= 0 || backoff > maxReconnectBackoff {
+		return maxReconnectBackoff
+	}
+	return backoff
+}
 
 var defaultInstrumentedHTTPClient = instrumentHTTPClient(http.DefaultClient)
 
@@ -66,8 +103,9 @@ type HTTPClient struct {
 	initializeRequest *Message
 	sessionID         *string
 
-	sseLock       sync.RWMutex
-	needReconnect bool
+	sseLock           sync.RWMutex
+	needReconnect     bool
+	reconnectFailures int
 
 	blockLoopback  bool
 	blockPrivateIP bool
@@ -477,6 +515,13 @@ func (s *HTTPClient) ensureSSE(ctx context.Context, msg *Message, lastEventID st
 
 		close(gotResponse)
 
+		// Track how long this stream stays up and whether it delivers any
+		// messages, so a stream that flaps (connects then closes almost
+		// immediately without delivering anything) can be backed off before
+		// the next reconnect.
+		connectedAt := time.Now()
+		messagesReceived := 0
+
 		for {
 			seenID, message, ok := messages.readNextMessage("message")
 			if seenID != "" {
@@ -508,6 +553,35 @@ func (s *HTTPClient) ensureSSE(ctx context.Context, msg *Message, lastEventID st
 					s.sseLock.Unlock()
 				}
 
+				// If the stream just flapped (closed quickly without delivering
+				// any messages), back off before reconnecting so we don't hammer
+				// a server that is rejecting or immediately dropping the stream
+				// (e.g. returning 429 Too Many Requests). A stream that stayed
+				// up long enough, or delivered messages, resets the backoff.
+				if streamFlapped(messagesReceived, time.Since(connectedAt)) {
+					s.sseLock.Lock()
+					s.reconnectFailures++
+					failures := s.reconnectFailures
+					s.sseLock.Unlock()
+
+					delay := reconnectBackoff(failures)
+					slog.Warn("mcp client event stream closed prematurely; backing off before reconnect",
+						"server", s.serverName,
+						"session_id", s.SessionID(),
+						"consecutive_failures", failures,
+						"delay", delay.String())
+
+					select {
+					case <-time.After(delay):
+					case <-s.ctx.Done():
+						return s.ctx.Err(), false
+					}
+				} else {
+					s.sseLock.Lock()
+					s.reconnectFailures = 0
+					s.sseLock.Unlock()
+				}
+
 				if err := s.ensureSSE(ctx, msg, lastEventID); err != nil {
 					return fmt.Errorf("failed to reconnect to SSE server: %v", err), false
 				}
@@ -520,6 +594,7 @@ func (s *HTTPClient) ensureSSE(ctx context.Context, msg *Message, lastEventID st
 				continue
 			}
 
+			messagesReceived++
 			log.Messages(ctx, s.serverName, false, []byte(message))
 			s.handler(s.ctx, msg)
 		}

--- a/pkg/mcp/httpclient_backoff_test.go
+++ b/pkg/mcp/httpclient_backoff_test.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReconnectBackoff verifies the exponential-with-cap schedule used to
+// space out reconnects to a flapping SSE stream. Without this backoff, a
+// downstream server that accepts and immediately drops (or rejects, e.g. with
+// 429) the event stream drives a tight reconnect loop that leaks resources on
+// every cycle.
+func TestReconnectBackoff(t *testing.T) {
+	tests := []struct {
+		name     string
+		failures int
+		want     time.Duration
+	}{
+		{"zero yields no delay", 0, 0},
+		{"negative yields no delay", -5, 0},
+		{"first failure is base", 1, baseReconnectBackoff},         // 500ms
+		{"second failure doubles", 2, 2 * baseReconnectBackoff},    // 1s
+		{"third failure quadruples", 3, 4 * baseReconnectBackoff},  // 2s
+		{"grows exponentially", 5, 16 * baseReconnectBackoff},      // 8s
+		{"last value under the cap", 6, 32 * baseReconnectBackoff}, // 16s
+		{"first value hitting the cap", 7, maxReconnectBackoff},    // 32s -> capped to 30s
+		{"is capped at max", 30, maxReconnectBackoff},
+		{"huge count stays capped (no overflow)", 1000, maxReconnectBackoff},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reconnectBackoff(tt.failures); got != tt.want {
+				t.Fatalf("reconnectBackoff(%d) = %v, want %v", tt.failures, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReconnectBackoffMonotonicAndBounded asserts the schedule never decreases
+// and never exceeds the cap for any positive count.
+func TestReconnectBackoffMonotonicAndBounded(t *testing.T) {
+	var prev time.Duration
+	for n := 1; n <= 64; n++ {
+		got := reconnectBackoff(n)
+		if got < prev {
+			t.Fatalf("reconnectBackoff(%d)=%v decreased from previous %v", n, got, prev)
+		}
+		if got > maxReconnectBackoff {
+			t.Fatalf("reconnectBackoff(%d)=%v exceeds cap %v", n, got, maxReconnectBackoff)
+		}
+		if got <= 0 {
+			t.Fatalf("reconnectBackoff(%d)=%v is non-positive for a positive count", n, got)
+		}
+		prev = got
+	}
+}
+
+// TestStreamFlapped verifies the decision that separates a healthy stream
+// (delivered a message, or stayed up long enough) from a flapping one that
+// should trigger reconnect backoff.
+func TestStreamFlapped(t *testing.T) {
+	tests := []struct {
+		name             string
+		messagesReceived int
+		streamDuration   time.Duration
+		want             bool
+	}{
+		{"short and silent flaps", 0, 100 * time.Millisecond, true},
+		{"just under threshold, silent, flaps", 0, minStableStreamDuration - time.Millisecond, true},
+		{"at threshold does not flap", 0, minStableStreamDuration, false},
+		{"long and silent does not flap", 0, minStableStreamDuration + time.Second, false},
+		{"short but delivered a message does not flap", 1, 10 * time.Millisecond, false},
+		{"delivered messages never flaps", 5, time.Nanosecond, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := streamFlapped(tt.messagesReceived, tt.streamDuration); got != tt.want {
+				t.Fatalf("streamFlapped(%d, %v) = %v, want %v",
+					tt.messagesReceived, tt.streamDuration, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`HTTPClient.ensureSSE` reconnects the SSE event stream **immediately** every time the stream closes (`pkg/mcp/httpclient.go`, the `!ok` branch of the read loop). If a downstream server accepts the `GET` event stream and then drops it right away — or rejects it outright with **429 Too Many Requests** — nanobot re-opens the stream in a tight loop, several times per second, doing a **fresh OAuth token exchange on every reconnect** and leaking per-connection resources each cycle. Memory grows unbounded.

I hit this in a real deployment: a single client reached **~34 GiB RSS** over 8 days. The event stream was reconnecting **~4×/second** (`connecting event stream` with `session_id=""` and `last_event_id=""` every time — i.e. the stream delivered nothing before closing), with the downstream returning `429`:

```
failed to connect to SSE server url http://…:8099: 429 Too Many Requests,
{"error":"too_many_requests","error_description":"Rate limit exceeded"}
```

Because the reconnect is immediate, the retries themselves sustain the rate-limit condition — a self-reinforcing storm.

## Fix

Treat a stream as **flapping** when it closes in under `minStableStreamDuration` (5s) without delivering any message, and apply **exponential backoff** (500ms → 30s cap) before the next reconnect. A stream that stays connected long enough, or that delivers a message, **resets** the backoff so healthy reconnects remain immediate.

This is intentionally minimal and self-contained:
- No behavior change for healthy streams (they never enter the flap path).
- Bounded, capped delay; overflow-guarded schedule.
- Backoff is interruptible via the client context (no added shutdown latency).

## Tests

`pkg/mcp/httpclient_backoff_test.go`:
- `reconnectBackoff` — exponential growth, cap at max, and no-overflow for huge counts; monotonic & bounded across a wide range.
- `streamFlapped` — the flap decision (duration threshold + message-delivered override).

`gofmt`, `go vet`, `go build`, and `go test ./...` all pass; no dependency changes.

## Notes

Independent of the underlying misconfiguration that produced the 429s in my case — this hardens nanobot so that *any* server which rejects or immediately drops the event stream can no longer drive an unbounded reconnect/token-exchange loop. Complementary to the session-teardown client-close fix in #325.