### PR TITLE
fix: bound MCP session resources under reconnect storms

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -269,12 +269,13 @@ func (n *Nanobot) Run(cmd *cobra.Command, _ []string) error {
 }
 
 type mcpOpts struct {
-	Auth                           auth.Auth
-	ListenAddress                  string
-	HealthzPath                    string
-	ForceFetchToolList             bool
-	StartUI                        bool
-	SessionGarbageCollectionPeriod time.Duration
+	Auth                   auth.Auth
+	ListenAddress          string
+	HealthzPath            string
+	ForceFetchToolList     bool
+	StartUI                bool
+	SessionManagerOptions  session.ManagerOptions
+	EventStreamMaxLifetime time.Duration
 }
 
 func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, runt *runtime.Runtime, oauthCallbackHandler mcp.CallbackServer, auditLogCollector auditlogs.Collector, store *session.Store, opts mcpOpts) error {
@@ -307,7 +308,7 @@ func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, ru
 		return fmt.Errorf("https:// is not supported, use http:// instead")
 	}
 
-	sessionManager := session.NewManager(ctx, store, opts.SessionGarbageCollectionPeriod)
+	sessionManager := session.NewManagerWithOptions(ctx, store, opts.SessionManagerOptions)
 
 	var mcpServer mcp.MessageHandler = server.NewServer(runt, config, sessionManager, server.Options{
 		ForceFetchToolList: opts.ForceFetchToolList,
@@ -324,10 +325,11 @@ func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, ru
 	}
 
 	httpServer, err := mcp.NewHTTPServer(envProvider, mcpServer, mcp.HTTPServerOptions{
-		HealthCheckPath:   opts.HealthzPath,
-		RunHealthChecker:  opts.HealthzPath != "" && os.Getenv("NANOBOT_DISABLE_HEALTH_CHECKER") != "true",
-		SessionStore:      sessionManager,
-		AuditLogCollector: auditLogCollector,
+		HealthCheckPath:        opts.HealthzPath,
+		RunHealthChecker:       opts.HealthzPath != "" && os.Getenv("NANOBOT_DISABLE_HEALTH_CHECKER") != "true",
+		SessionStore:           sessionManager,
+		AuditLogCollector:      auditLogCollector,
+		EventStreamMaxLifetime: opts.EventStreamMaxLifetime,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP server: %w", err)

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -3,9 +3,13 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	cmdpkg "github.com/obot-platform/nanobot/pkg/cmd"
 	"github.com/obot-platform/nanobot/pkg/config"
+	"github.com/obot-platform/nanobot/pkg/session"
 )
 
 func TestNanobotConfigPathsDefault(t *testing.T) {
@@ -43,5 +47,103 @@ func TestRuntimeConfigDirReturnsFileParentDirectory(t *testing.T) {
 	configDir := runtimeConfigDir([]string{path})
 	if configDir != dir {
 		t.Fatalf("expected config dir %q, got %q", dir, configDir)
+	}
+}
+
+func TestRunSessionLifecycleFlagsExposeBoundedDefaultsAndEnvironmentVariables(t *testing.T) {
+	run := NewRun(&Nanobot{})
+	command := cmdpkg.Command(run)
+
+	tests := []struct {
+		name         string
+		defaultValue string
+		env          string
+	}{
+		{name: "max-live-sessions", defaultValue: "4", env: "NANOBOT_MAX_LIVE_SESSIONS"},
+		{name: "live-session-idle-ttl", defaultValue: "10s", env: "NANOBOT_LIVE_SESSION_IDLE_TTL"},
+		{name: "event-stream-max-lifetime", defaultValue: "5m", env: "NANOBOT_EVENT_STREAM_MAX_LIFETIME"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := command.PersistentFlags().Lookup(tt.name)
+			if flag == nil {
+				t.Fatalf("flag --%s was not registered", tt.name)
+			}
+			if flag.DefValue != tt.defaultValue {
+				t.Fatalf("--%s default = %q, want %q", tt.name, flag.DefValue, tt.defaultValue)
+			}
+			if !strings.Contains(flag.Usage, "$"+tt.env) {
+				t.Fatalf("--%s help does not mention $%s: %q", tt.name, tt.env, flag.Usage)
+			}
+		})
+	}
+}
+
+func TestRunSessionLifecycleOptions(t *testing.T) {
+	run := &Run{
+		SessionGCPeriod:        "168h",
+		LiveSessionIdleTTL:     "10s",
+		MaxLiveSessions:        4,
+		EventStreamMaxLifetime: "5m",
+	}
+
+	managerOptions, streamLifetime, err := run.sessionLifecycleOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if managerOptions.DatabaseGarbageCollectionPeriod != 168*time.Hour {
+		t.Fatalf("database GC period = %s", managerOptions.DatabaseGarbageCollectionPeriod)
+	}
+	if managerOptions.LiveSessionIdleTTL != session.DefaultLiveSessionIdleTTL {
+		t.Fatalf("live session idle TTL = %s", managerOptions.LiveSessionIdleTTL)
+	}
+	if managerOptions.MaxLiveSessions != session.DefaultMaxLiveSessions {
+		t.Fatalf("max live sessions = %d", managerOptions.MaxLiveSessions)
+	}
+	if streamLifetime != 5*time.Minute {
+		t.Fatalf("event stream max lifetime = %s", streamLifetime)
+	}
+}
+
+func TestRunSessionLifecycleOptionsRejectInvalidValues(t *testing.T) {
+	tests := []struct {
+		name string
+		run  Run
+	}{
+		{
+			name: "non-positive max sessions",
+			run: Run{
+				SessionGCPeriod:        "168h",
+				LiveSessionIdleTTL:     "10s",
+				MaxLiveSessions:        0,
+				EventStreamMaxLifetime: "5m",
+			},
+		},
+		{
+			name: "non-positive idle TTL",
+			run: Run{
+				SessionGCPeriod:        "168h",
+				LiveSessionIdleTTL:     "0s",
+				MaxLiveSessions:        4,
+				EventStreamMaxLifetime: "5m",
+			},
+		},
+		{
+			name: "non-positive stream lifetime",
+			run: Run{
+				SessionGCPeriod:        "168h",
+				LiveSessionIdleTTL:     "10s",
+				MaxLiveSessions:        4,
+				EventStreamMaxLifetime: "0s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := tt.run.sessionLifecycleOptions(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
 	}
 }

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -32,6 +32,9 @@ type Run struct {
 	AuditLogBatchSize            int               `usage:"Batch size for sending audit logs" default:"1000"`
 	AuditLogFlushIntervalSeconds int               `usage:"Interval for flushing audit logs" default:"5"`
 	SessionGCPeriod              string            `usage:"How long idle sessions are kept before garbage collection; <= 0 disables garbage collection. Examples: 168h, 30m" default:"168h"`
+	LiveSessionIdleTTL           string            `usage:"How long an unreferenced live MCP session may retain downstream resources" default:"10s" env:"NANOBOT_LIVE_SESSION_IDLE_TTL"`
+	MaxLiveSessions              int               `usage:"Maximum live MCP sessions that may retain downstream resources" default:"4" env:"NANOBOT_MAX_LIVE_SESSIONS"`
+	EventStreamMaxLifetime       string            `usage:"Maximum lifetime of one MCP event stream before the client must reconnect" default:"5m" env:"NANOBOT_EVENT_STREAM_MAX_LIFETIME"`
 	Roots                        []string          `usage:"Roots to expose the MCP server in the form of name:directory" short:"r"`
 	EntrypointAgent              string            `usage:"ID of the agent to use for chat" name:"agent"`
 	BlockLoopback                bool              `usage:"Block MCP HTTP requests to loopback IP addresses"`
@@ -127,9 +130,9 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("trusted issuer and audience must be set together")
 	}
 
-	sessionGarbageCollectionPeriod, err := time.ParseDuration(r.SessionGCPeriod)
+	sessionManagerOptions, eventStreamMaxLifetime, err := r.sessionLifecycleOptions()
 	if err != nil {
-		return fmt.Errorf("invalid session GC period %q: %w", r.SessionGCPeriod, err)
+		return err
 	}
 
 	roots, err := r.getRoots()
@@ -211,11 +214,40 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	return r.n.runMCP(cmd.Context(), cfgFactory, runtime, callbackHandler, auditLogCollector, store, mcpOpts{
-		Auth:                           auth.Auth(r.Auth),
-		ListenAddress:                  r.ListenAddress,
-		HealthzPath:                    r.HealthzPath,
-		ForceFetchToolList:             r.ForceFetchToolList,
-		StartUI:                        !r.DisableUI,
-		SessionGarbageCollectionPeriod: sessionGarbageCollectionPeriod,
+		Auth:                   auth.Auth(r.Auth),
+		ListenAddress:          r.ListenAddress,
+		HealthzPath:            r.HealthzPath,
+		ForceFetchToolList:     r.ForceFetchToolList,
+		StartUI:                !r.DisableUI,
+		EventStreamMaxLifetime: eventStreamMaxLifetime,
+		SessionManagerOptions:  sessionManagerOptions,
 	})
+}
+
+func (r *Run) sessionLifecycleOptions() (session.ManagerOptions, time.Duration, error) {
+	sessionGarbageCollectionPeriod, err := time.ParseDuration(r.SessionGCPeriod)
+	if err != nil {
+		return session.ManagerOptions{}, 0,
+			fmt.Errorf("invalid session GC period %q: %w", r.SessionGCPeriod, err)
+	}
+	liveSessionIdleTTL, err := time.ParseDuration(r.LiveSessionIdleTTL)
+	if err != nil || liveSessionIdleTTL <= 0 {
+		return session.ManagerOptions{}, 0,
+			fmt.Errorf("invalid live session idle TTL %q: must be a positive duration", r.LiveSessionIdleTTL)
+	}
+	eventStreamMaxLifetime, err := time.ParseDuration(r.EventStreamMaxLifetime)
+	if err != nil || eventStreamMaxLifetime <= 0 {
+		return session.ManagerOptions{}, 0,
+			fmt.Errorf("invalid event stream max lifetime %q: must be a positive duration", r.EventStreamMaxLifetime)
+	}
+	if r.MaxLiveSessions <= 0 {
+		return session.ManagerOptions{}, 0,
+			fmt.Errorf("invalid max live sessions %d: must be positive", r.MaxLiveSessions)
+	}
+
+	return session.ManagerOptions{
+		DatabaseGarbageCollectionPeriod: sessionGarbageCollectionPeriod,
+		LiveSessionIdleTTL:              liveSessionIdleTTL,
+		MaxLiveSessions:                 r.MaxLiveSessions,
+	}, eventStreamMaxLifetime, nil
 }

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -608,8 +608,8 @@ func (s *HTTPClient) initialize(ctx context.Context, msg Message) error {
 		"status_code", resp.StatusCode)
 
 	go func() {
-		if err = s.ensureSSE(ctx, nil, ""); err != nil {
-			slog.Error("failed to initialize SSE", "error", err)
+		if sseErr := s.ensureSSE(ctx, nil, ""); sseErr != nil {
+			slog.Error("failed to initialize SSE", "error", sseErr)
 		}
 	}()
 

--- a/pkg/mcp/httpclient_race_test.go
+++ b/pkg/mcp/httpclient_race_test.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestHTTPClientInitializeDoesNotShareSSEErrorState(t *testing.T) {
+	readStarted := make(chan struct{})
+	releaseRead := make(chan struct{})
+
+	client, err := newHTTPClient(
+		"race-test",
+		Server{BaseURL: "http://mcp.example/mcp"},
+		HTTPClientOptions{},
+		nil,
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Start(context.Background(), func(context.Context, Message) {}); err != nil {
+		t.Fatal(err)
+	}
+	client.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case http.MethodPost:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     http.StatusText(http.StatusOK),
+					Header: http.Header{
+						"Content-Type":  []string{"application/json"},
+						SessionIDHeader: []string{"race-session"},
+					},
+					Body: &synchronizedReadCloser{
+						Reader:      strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"test","version":"1"}}}`),
+						readStarted: readStarted,
+						release:     releaseRead,
+					},
+					Request: req,
+				}, nil
+			case http.MethodGet:
+				<-readStarted
+				close(releaseRead)
+				return nil, errors.New("event stream unavailable")
+			default:
+				return nil, errors.New("unexpected HTTP method")
+			}
+		}),
+	}
+
+	if err := client.initialize(context.Background(), Message{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params:  []byte(`{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client.Close(false)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type synchronizedReadCloser struct {
+	io.Reader
+	once        sync.Once
+	readStarted chan struct{}
+	release     <-chan struct{}
+}
+
+func (r *synchronizedReadCloser) Read(p []byte) (int, error) {
+	r.once.Do(func() {
+		close(r.readStarted)
+		<-r.release
+	})
+	return r.Reader.Read(p)
+}
+
+func (*synchronizedReadCloser) Close() error {
+	return nil
+}

--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -20,6 +20,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const DefaultEventStreamMaxLifetime = 5 * time.Minute
+
 // responseRecorder is an http.ResponseWriter that captures the response for audit logging
 type responseRecorder struct {
 	http.ResponseWriter
@@ -120,24 +122,30 @@ type HTTPServer struct {
 	healthErr       *error
 	healthMu        sync.RWMutex
 
-	auditLogCollector auditlogs.Collector
+	auditLogCollector      auditlogs.Collector
+	eventStreamMaxLifetime time.Duration
 }
 
 type HTTPServerOptions struct {
-	SessionStore      SessionStore
-	BaseContext       context.Context
-	HealthCheckPath   string
-	ResourceName      string
-	RunHealthChecker  bool
-	AuditLogCollector auditlogs.Collector
+	SessionStore                SessionStore
+	InMemorySessionStoreOptions InMemorySessionStoreOptions
+	BaseContext                 context.Context
+	HealthCheckPath             string
+	ResourceName                string
+	RunHealthChecker            bool
+	AuditLogCollector           auditlogs.Collector
+	EventStreamMaxLifetime      time.Duration
 }
 
 func (h HTTPServerOptions) Complete() HTTPServerOptions {
-	if h.SessionStore == nil {
-		h.SessionStore = NewInMemorySessionStore()
-	}
 	if h.BaseContext == nil {
 		h.BaseContext = context.Background()
+	}
+	if h.SessionStore == nil {
+		if h.InMemorySessionStoreOptions.BaseContext == nil {
+			h.InMemorySessionStoreOptions.BaseContext = h.BaseContext
+		}
+		h.SessionStore = NewInMemorySessionStoreWithOptions(h.InMemorySessionStoreOptions)
 	}
 	if h.AuditLogCollector == nil {
 		h.AuditLogCollector = auditlogs.NewNoopCollector()
@@ -145,28 +153,36 @@ func (h HTTPServerOptions) Complete() HTTPServerOptions {
 	if h.ResourceName == "" {
 		h.ResourceName = "Nanobot MCP Server"
 	}
+	if h.EventStreamMaxLifetime == 0 {
+		h.EventStreamMaxLifetime = DefaultEventStreamMaxLifetime
+	} else if h.EventStreamMaxLifetime < 0 {
+		h.EventStreamMaxLifetime = 0
+	}
 	return h
 }
 
 func (h HTTPServerOptions) Merge(other HTTPServerOptions) (result HTTPServerOptions) {
 	h.SessionStore = complete.Last(h.SessionStore, other.SessionStore)
+	h.InMemorySessionStoreOptions = h.InMemorySessionStoreOptions.Merge(other.InMemorySessionStoreOptions)
 	h.BaseContext = complete.Last(h.BaseContext, other.BaseContext)
 	h.RunHealthChecker = complete.Last(h.RunHealthChecker, other.RunHealthChecker)
 	h.HealthCheckPath = complete.Last(h.HealthCheckPath, other.HealthCheckPath)
 	h.ResourceName = complete.Last(h.ResourceName, other.ResourceName)
 	h.AuditLogCollector = complete.Last(h.AuditLogCollector, other.AuditLogCollector)
+	h.EventStreamMaxLifetime = complete.Last(h.EventStreamMaxLifetime, other.EventStreamMaxLifetime)
 	return h
 }
 
 func NewHTTPServer(envProvider func() (map[string]string, error), handler MessageHandler, opts ...HTTPServerOptions) (*HTTPServer, error) {
 	o := complete.Complete(opts...)
 	h := &HTTPServer{
-		MessageHandler:    handler,
-		mux:               http.NewServeMux(),
-		envProvider:       envProvider,
-		sessions:          o.SessionStore,
-		ctx:               o.BaseContext,
-		auditLogCollector: o.AuditLogCollector,
+		MessageHandler:         handler,
+		mux:                    http.NewServeMux(),
+		envProvider:            envProvider,
+		sessions:               o.SessionStore,
+		ctx:                    o.BaseContext,
+		auditLogCollector:      o.AuditLogCollector,
+		eventStreamMaxLifetime: o.EventStreamMaxLifetime,
 	}
 
 	if o.HealthCheckPath != "" {
@@ -236,10 +252,20 @@ func (h *HTTPServer) streamEvents(rw http.ResponseWriter, req *http.Request, aud
 	// message is delivered to all of them. The done channel signals session
 	// closure so we don't hang after the session is torn down.
 	ch, done := session.Subscribe(req.Context())
+	var lifetime <-chan time.Time
+	var lifetimeTimer *time.Timer
+	if h.eventStreamMaxLifetime > 0 {
+		lifetimeTimer = time.NewTimer(h.eventStreamMaxLifetime)
+		lifetime = lifetimeTimer.C
+		defer lifetimeTimer.Stop()
+	}
 
 	for {
 		select {
-		case msg := <-ch:
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
 			data, _ := json.Marshal(msg)
 			_, err := rw.Write([]byte("data: " + string(data) + "\n\n"))
 			if err != nil {
@@ -250,6 +276,11 @@ func (h *HTTPServer) streamEvents(rw http.ResponseWriter, req *http.Request, aud
 			}
 		case <-done:
 			slog.Debug("mcp server event stream closed", "session_id", id)
+			return
+		case <-lifetime:
+			slog.Info("mcp server event stream reached maximum lifetime",
+				"session_id", id,
+				"max_lifetime", h.eventStreamMaxLifetime)
 			return
 		}
 	}
@@ -478,6 +509,17 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	releaseReservation := func() {}
+	if reserver, ok := h.sessions.(SessionStoreReserver); ok {
+		releaseReservation, err = reserver.Reserve(ctx)
+		if err != nil {
+			slog.Warn("mcp server failed to reserve session capacity", "error", err)
+			respondSessionStoreError(rw, err)
+			return
+		}
+		defer releaseReservation()
+	}
+
 	session, err := NewServerSession(h.ctx, h.MessageHandler, ServerSessionOptions{
 		DefaultAgent: req.Header.Get("X-Nanobot-Default-Agent"),
 	})
@@ -522,6 +564,9 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 	if err := h.sessions.Store(ctx, session.ID(), session); err != nil {
 		slog.Error("mcp server failed to persist session", "session_id", session.ID(), "error", err)
 		session.Close(true)
+		if respondSessionStoreError(rw, err) {
+			return
+		}
 		http.Error(rw, fmt.Sprintf(`{"http_error": "Failed to store session: %v"}`, err), http.StatusInternalServerError)
 		return
 	}
@@ -532,6 +577,20 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, fmt.Sprintf(`{"http_error": "Failed to encode response: %v"}`, err), http.StatusInternalServerError)
 		return
 	}
+}
+
+func respondSessionStoreError(rw http.ResponseWriter, err error) bool {
+	if errors.Is(err, ErrSessionCapacity) {
+		rw.Header().Set("Retry-After", "1")
+		http.Error(rw, `{"http_error": "Session capacity reached"}`, http.StatusServiceUnavailable)
+		return true
+	}
+	if errors.Is(err, ErrSessionStoreClosed) {
+		rw.Header().Set("Retry-After", "1")
+		http.Error(rw, `{"http_error": "Session store is shutting down"}`, http.StatusServiceUnavailable)
+		return true
+	}
+	return false
 }
 
 func respondWithUnauthorized(rw http.ResponseWriter, req *http.Request) {
@@ -629,6 +688,16 @@ func (h *HTTPServer) ensureInternalSession(ctx context.Context) (*ServerSession,
 	h.healthMu.RUnlock()
 	if s != nil {
 		return s, nil
+	}
+
+	releaseReservation := func() {}
+	if reserver, ok := h.sessions.(SessionStoreReserver); ok {
+		var err error
+		releaseReservation, err = reserver.Reserve(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reserve internal session capacity: %w", err)
+		}
+		defer releaseReservation()
 	}
 
 	session, err := NewServerSession(h.ctx, h.MessageHandler)

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -461,6 +461,23 @@ func (s *Session) Attributes() map[string]any {
 }
 
 func (s *Session) Close(deleteSession bool) {
+	// Close any attribute that owns a closable resource (e.g. downstream MCP
+	// client factories). Otherwise those clients are orphaned when the session
+	// is torn down: their upstream session is never deleted and their reader
+	// goroutines leak. Snapshot under the lock, then close without holding it so
+	// a closer may call back into the session without deadlocking.
+	s.lock.Lock()
+	var closers []interface{ Close(bool) }
+	for _, v := range s.attributes {
+		if c, ok := v.(interface{ Close(bool) }); ok {
+			closers = append(closers, c)
+		}
+	}
+	s.lock.Unlock()
+	for _, c := range closers {
+		c.Close(deleteSession)
+	}
+
 	if s.wire != nil {
 		s.wire.Close(deleteSession)
 	}

--- a/pkg/mcp/session_close_test.go
+++ b/pkg/mcp/session_close_test.go
@@ -1,0 +1,42 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+// recordingCloser records the deleteSession values it was closed with.
+type recordingCloser struct {
+	closed []bool
+}
+
+func (r *recordingCloser) Close(deleteSession bool) {
+	r.closed = append(r.closed, deleteSession)
+}
+
+// TestSessionCloseClosesAttributeClosers verifies that closing a session also
+// closes any attribute value that owns a closable resource (such as a
+// downstream MCP client factory). Without this, downstream clients stored in
+// session attributes are orphaned when the session is torn down: their upstream
+// MCP session is never deleted (no DELETE is sent) and their goroutines leak.
+func TestSessionCloseClosesAttributeClosers(t *testing.T) {
+	for _, deleteSession := range []bool{true, false} {
+		sess := NewEmptySession(context.Background())
+
+		rc := &recordingCloser{}
+		sess.Set("clients/grocy", rc)
+		// A non-closer attribute must be left untouched (and must not panic).
+		sess.Set("config-hash", SavedString("abc123"))
+
+		sess.Close(deleteSession)
+
+		if len(rc.closed) != 1 {
+			t.Fatalf("deleteSession=%v: expected closable attribute to be closed exactly once, got %d calls (%v)",
+				deleteSession, len(rc.closed), rc.closed)
+		}
+		if rc.closed[0] != deleteSession {
+			t.Fatalf("deleteSession=%v: expected closer to receive %v, got %v",
+				deleteSession, deleteSession, rc.closed[0])
+		}
+	}
+}

--- a/pkg/mcp/sessionstore.go
+++ b/pkg/mcp/sessionstore.go
@@ -2,9 +2,50 @@ package mcp
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 )
+
+const (
+	// DefaultInMemorySessionIdleTTL is how long an unreferenced session remains
+	// available before the in-memory store closes it.
+	DefaultInMemorySessionIdleTTL = 30 * time.Minute
+	// DefaultInMemorySessionReapInterval controls how frequently the in-memory
+	// store looks for expired sessions.
+	DefaultInMemorySessionReapInterval = time.Minute
+	// DefaultInMemorySessionMaxSessions bounds the number of sessions retained
+	// by a default in-memory store.
+	DefaultInMemorySessionMaxSessions = 32
+)
+
+var (
+	// ErrSessionCapacity indicates that a bounded session store has no idle
+	// session available for eviction.
+	ErrSessionCapacity = errors.New("session store capacity reached")
+	// ErrSessionStoreClosed indicates that the store has begun shutting down.
+	ErrSessionStoreClosed = errors.New("session store is closed")
+)
+
+// SessionCapacityError describes a failed attempt to store a session while
+// every retained session is acquired.
+type SessionCapacityError struct {
+	MaxSessions     int
+	ActiveSessions  int
+	PendingSessions int
+}
+
+func (e *SessionCapacityError) Error() string {
+	return fmt.Sprintf("%v: %d active and %d pending sessions (limit %d)",
+		ErrSessionCapacity, e.ActiveSessions, e.PendingSessions, e.MaxSessions)
+}
+
+func (e *SessionCapacityError) Unwrap() error {
+	return ErrSessionCapacity
+}
 
 type SessionStore interface {
 	ExtractID(*http.Request) string
@@ -14,36 +55,365 @@ type SessionStore interface {
 	LoadAndDelete(context.Context, MessageHandler, string) (*ServerSession, bool, error)
 }
 
-type inMemory struct {
-	sessions sync.Map
+// SessionStoreReserver allows an HTTP server to reserve capacity before it
+// initializes a session and creates any session-scoped downstream resources.
+// The returned release function must be called exactly once on every path.
+type SessionStoreReserver interface {
+	Reserve(context.Context) (release func(), err error)
 }
 
+// InMemorySessionStoreOptions configures in-memory session lifetime and
+// capacity. All zero values receive bounded production defaults.
+type InMemorySessionStoreOptions struct {
+	BaseContext  context.Context
+	IdleTTL      time.Duration
+	ReapInterval time.Duration
+	MaxSessions  int
+}
+
+func (o InMemorySessionStoreOptions) Complete() InMemorySessionStoreOptions {
+	if o.BaseContext == nil {
+		o.BaseContext = context.Background()
+	}
+	if o.IdleTTL <= 0 {
+		o.IdleTTL = DefaultInMemorySessionIdleTTL
+	}
+	if o.ReapInterval <= 0 {
+		o.ReapInterval = DefaultInMemorySessionReapInterval
+	}
+	if o.MaxSessions <= 0 {
+		o.MaxSessions = DefaultInMemorySessionMaxSessions
+	}
+	return o
+}
+
+func (o InMemorySessionStoreOptions) Merge(other InMemorySessionStoreOptions) InMemorySessionStoreOptions {
+	if other.BaseContext != nil {
+		o.BaseContext = other.BaseContext
+	}
+	if other.IdleTTL != 0 {
+		o.IdleTTL = other.IdleTTL
+	}
+	if other.ReapInterval != 0 {
+		o.ReapInterval = other.ReapInterval
+	}
+	if other.MaxSessions != 0 {
+		o.MaxSessions = other.MaxSessions
+	}
+	return o
+}
+
+type inMemorySession struct {
+	session    *ServerSession
+	references int
+	lastUsed   time.Time
+}
+
+type InMemorySessionStore struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu          sync.Mutex
+	closed      bool
+	sessions    map[string]*inMemorySession
+	pending     int
+	idleTTL     time.Duration
+	maxSessions int
+}
+
+// NewInMemorySessionStore preserves the original constructor while applying
+// bounded defaults. Use NewInMemorySessionStoreWithOptions to tune them.
 func NewInMemorySessionStore() SessionStore {
-	return &inMemory{}
+	return NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{})
 }
 
-func (s *inMemory) ExtractID(req *http.Request) string {
+// NewInMemorySessionStoreWithOptions creates an in-memory session store and
+// starts its idle-session reaper. Close the returned store, or cancel
+// BaseContext, to stop the reaper and close all retained sessions.
+func NewInMemorySessionStoreWithOptions(opts InMemorySessionStoreOptions) *InMemorySessionStore {
+	o := opts.Complete()
+
+	ctx, cancel := context.WithCancel(o.BaseContext)
+	store := &InMemorySessionStore{
+		cancel:      cancel,
+		done:        make(chan struct{}),
+		sessions:    make(map[string]*inMemorySession),
+		idleTTL:     o.IdleTTL,
+		maxSessions: o.MaxSessions,
+	}
+	go store.runReaper(ctx, o.ReapInterval)
+	return store
+}
+
+func (s *InMemorySessionStore) ExtractID(req *http.Request) string {
 	return req.Header.Get("Mcp-Session-Id")
 }
 
-func (s *inMemory) Store(_ context.Context, sessionID string, session *ServerSession) error {
-	s.sessions.Store(sessionID, session)
+func (s *InMemorySessionStore) Reserve(_ context.Context) (func(), error) {
+	var evicted *ServerSession
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrSessionStoreClosed
+	}
+
+	if len(s.sessions)+s.pending >= s.maxSessions {
+		var (
+			evictionID string
+			eviction   *inMemorySession
+		)
+		for id, candidate := range s.sessions {
+			if candidate.references != 0 {
+				continue
+			}
+			if eviction == nil || candidate.lastUsed.Before(eviction.lastUsed) {
+				evictionID = id
+				eviction = candidate
+			}
+		}
+		if eviction == nil {
+			err := &SessionCapacityError{
+				MaxSessions:     s.maxSessions,
+				ActiveSessions:  len(s.sessions),
+				PendingSessions: s.pending,
+			}
+			s.mu.Unlock()
+			return nil, err
+		}
+		delete(s.sessions, evictionID)
+		evicted = eviction.session
+		slog.Info("evicting idle MCP session to reserve in-memory store capacity",
+			"session_id", evictionID,
+			"max_sessions", s.maxSessions)
+	}
+
+	s.pending++
+	s.mu.Unlock()
+
+	if evicted != nil {
+		evicted.Close(true)
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.mu.Lock()
+			if s.pending > 0 {
+				s.pending--
+			}
+			s.mu.Unlock()
+		})
+	}, nil
+}
+
+func (s *InMemorySessionStore) Store(_ context.Context, sessionID string, session *ServerSession) error {
+	if session == nil {
+		return errors.New("session is nil")
+	}
+	if sessionID == "" {
+		return errors.New("session ID is empty")
+	}
+	if session.ID() != sessionID {
+		return fmt.Errorf("session ID %q does not match stored session ID %q", sessionID, session.ID())
+	}
+
+	now := time.Now()
+	var toClose []*ServerSession
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrSessionStoreClosed
+	}
+
+	if existing, ok := s.sessions[sessionID]; ok {
+		if existing.session == session {
+			existing.lastUsed = now
+			s.mu.Unlock()
+			return nil
+		}
+		if existing.references > 0 {
+			s.mu.Unlock()
+			return fmt.Errorf("session %q is already acquired by another instance", sessionID)
+		}
+		delete(s.sessions, sessionID)
+		toClose = append(toClose, existing.session)
+	}
+
+	if len(s.sessions) >= s.maxSessions {
+		var (
+			evictionID string
+			eviction   *inMemorySession
+		)
+		for id, candidate := range s.sessions {
+			if candidate.references != 0 {
+				continue
+			}
+			if eviction == nil || candidate.lastUsed.Before(eviction.lastUsed) {
+				evictionID = id
+				eviction = candidate
+			}
+		}
+		if eviction == nil {
+			activeSessions := len(s.sessions)
+			s.mu.Unlock()
+			for _, replaced := range toClose {
+				replaced.Close(true)
+			}
+			return &SessionCapacityError{
+				MaxSessions:     s.maxSessions,
+				ActiveSessions:  activeSessions,
+				PendingSessions: s.pending,
+			}
+		}
+		delete(s.sessions, evictionID)
+		toClose = append(toClose, eviction.session)
+		slog.Info("evicting idle MCP session at in-memory store capacity",
+			"session_id", evictionID,
+			"max_sessions", s.maxSessions)
+	}
+
+	s.sessions[sessionID] = &inMemorySession{
+		session:    session,
+		references: 1,
+		lastUsed:   now,
+	}
+	s.mu.Unlock()
+
+	for _, replacedOrEvicted := range toClose {
+		replacedOrEvicted.Close(true)
+	}
 	return nil
 }
 
-func (s *inMemory) Acquire(_ context.Context, _ MessageHandler, sessionID string) (*ServerSession, bool, error) {
-	if v, ok := s.sessions.Load(sessionID); ok {
-		return v.(*ServerSession), true, nil
+func (s *InMemorySessionStore) Acquire(_ context.Context, _ MessageHandler, sessionID string) (*ServerSession, bool, error) {
+	now := time.Now()
+	var toClose *ServerSession
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, false, ErrSessionStoreClosed
 	}
-	return nil, false, nil
+
+	entry, ok := s.sessions[sessionID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, false, nil
+	}
+
+	if !entry.session.GetSession().IsActive() ||
+		(entry.references == 0 && now.Sub(entry.lastUsed) >= s.idleTTL) {
+		delete(s.sessions, sessionID)
+		toClose = entry.session
+		s.mu.Unlock()
+		toClose.Close(true)
+		return nil, false, nil
+	}
+
+	entry.references++
+	entry.lastUsed = now
+	session := entry.session
+	s.mu.Unlock()
+	return session, true, nil
 }
 
-func (s *inMemory) Release(*ServerSession) {
+func (s *InMemorySessionStore) Release(session *ServerSession) {
+	if session == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.sessions[session.ID()]
+	if !ok || entry.session != session || entry.references == 0 {
+		return
+	}
+
+	entry.references--
+	if entry.references == 0 {
+		entry.lastUsed = time.Now()
+	}
 }
 
-func (s *inMemory) LoadAndDelete(_ context.Context, _ MessageHandler, sessionID string) (*ServerSession, bool, error) {
-	if v, ok := s.sessions.LoadAndDelete(sessionID); ok {
-		return v.(*ServerSession), true, nil
+func (s *InMemorySessionStore) LoadAndDelete(_ context.Context, _ MessageHandler, sessionID string) (*ServerSession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil, false, ErrSessionStoreClosed
 	}
-	return nil, false, nil
+
+	entry, ok := s.sessions[sessionID]
+	if !ok {
+		return nil, false, nil
+	}
+	delete(s.sessions, sessionID)
+	return entry.session, true, nil
+}
+
+func (s *InMemorySessionStore) Close() error {
+	s.cancel()
+	<-s.done
+	return nil
+}
+
+func (s *InMemorySessionStore) runReaper(ctx context.Context, interval time.Duration) {
+	defer close(s.done)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.closeAll()
+			return
+		case now := <-ticker.C:
+			s.reap(now)
+		}
+	}
+}
+
+func (s *InMemorySessionStore) reap(now time.Time) {
+	var expired []*ServerSession
+
+	s.mu.Lock()
+	if !s.closed {
+		for id, entry := range s.sessions {
+			if entry.references == 0 && now.Sub(entry.lastUsed) >= s.idleTTL {
+				delete(s.sessions, id)
+				expired = append(expired, entry.session)
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	if len(expired) > 0 {
+		slog.Info("reaping idle MCP sessions", "count", len(expired), "idle_ttl", s.idleTTL)
+	}
+	for _, session := range expired {
+		session.Close(true)
+	}
+}
+
+func (s *InMemorySessionStore) closeAll() {
+	var sessions []*ServerSession
+
+	s.mu.Lock()
+	if !s.closed {
+		s.closed = true
+		sessions = make([]*ServerSession, 0, len(s.sessions))
+		for id, entry := range s.sessions {
+			delete(s.sessions, id)
+			sessions = append(sessions, entry.session)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, session := range sessions {
+		session.Close(true)
+	}
 }

--- a/pkg/mcp/sessionstore_test.go
+++ b/pkg/mcp/sessionstore_test.go
@@ -1,0 +1,288 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestInMemorySessionStoreReapsIdleSessions(t *testing.T) {
+	store := NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{
+		IdleTTL:      20 * time.Millisecond,
+		ReapInterval: 5 * time.Millisecond,
+		MaxSessions:  4,
+	})
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close session store: %v", err)
+		}
+	})
+
+	session := newSessionStoreTestSession(t, "idle")
+	if err := store.Store(context.Background(), session.ID(), session); err != nil {
+		t.Fatal(err)
+	}
+	store.Release(session)
+
+	waitForSessionClose(t, session, time.Second)
+
+	if _, found, err := store.Acquire(context.Background(), nil, session.ID()); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("expired session remained available")
+	}
+}
+
+func TestInMemorySessionStoreDoesNotReapAcquiredSessions(t *testing.T) {
+	store := NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{
+		IdleTTL:      20 * time.Millisecond,
+		ReapInterval: 5 * time.Millisecond,
+		MaxSessions:  4,
+	})
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close session store: %v", err)
+		}
+	})
+
+	session := newSessionStoreTestSession(t, "acquired")
+	if err := store.Store(context.Background(), session.ID(), session); err != nil {
+		t.Fatal(err)
+	}
+	store.Release(session)
+
+	acquired, found, err := store.Acquire(context.Background(), nil, session.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("session was not found")
+	}
+
+	time.Sleep(4 * 20 * time.Millisecond)
+	select {
+	case <-session.GetSession().Context().Done():
+		t.Fatal("acquired session was reaped")
+	default:
+	}
+
+	store.Release(acquired)
+	waitForSessionClose(t, session, time.Second)
+}
+
+func TestInMemorySessionStoreEvictsLeastRecentlyUsedIdleSessionAtCapacity(t *testing.T) {
+	store := NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{
+		IdleTTL:      time.Hour,
+		ReapInterval: time.Minute,
+		MaxSessions:  2,
+	})
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close session store: %v", err)
+		}
+	})
+
+	first := newSessionStoreTestSession(t, "first")
+	second := newSessionStoreTestSession(t, "second")
+	third := newSessionStoreTestSession(t, "third")
+
+	storeSessionThenRelease(t, store, first)
+	time.Sleep(time.Millisecond)
+	storeSessionThenRelease(t, store, second)
+
+	touched, found, err := store.Acquire(context.Background(), nil, first.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("first session was not found")
+	}
+	store.Release(touched)
+
+	if err := store.Store(context.Background(), third.ID(), third); err != nil {
+		t.Fatal(err)
+	}
+	store.Release(third)
+
+	waitForSessionClose(t, second, time.Second)
+	select {
+	case <-first.GetSession().Context().Done():
+		t.Fatal("most recently used idle session was evicted")
+	default:
+	}
+
+	if _, found, err := store.Acquire(context.Background(), nil, second.ID()); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("least recently used session remained available")
+	}
+}
+
+func TestInMemorySessionStoreReturnsTypedCapacityErrorWhenAllSessionsAreAcquired(t *testing.T) {
+	store := NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{
+		IdleTTL:      time.Hour,
+		ReapInterval: time.Minute,
+		MaxSessions:  2,
+	})
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close session store: %v", err)
+		}
+	})
+
+	first := newSessionStoreTestSession(t, "first")
+	second := newSessionStoreTestSession(t, "second")
+	third := newSessionStoreTestSession(t, "third")
+
+	if err := store.Store(context.Background(), first.ID(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Store(context.Background(), second.ID(), second); err != nil {
+		t.Fatal(err)
+	}
+
+	err := store.Store(context.Background(), third.ID(), third)
+	if !errors.Is(err, ErrSessionCapacity) {
+		t.Fatalf("expected ErrSessionCapacity, got %v", err)
+	}
+	var capacityErr *SessionCapacityError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected *SessionCapacityError, got %T", err)
+	}
+	if capacityErr.MaxSessions != 2 || capacityErr.ActiveSessions != 2 {
+		t.Fatalf("unexpected capacity details: %#v", capacityErr)
+	}
+
+	for _, session := range []*ServerSession{first, second} {
+		select {
+		case <-session.GetSession().Context().Done():
+			t.Fatalf("acquired session %q was evicted", session.ID())
+		default:
+		}
+	}
+
+	third.Close(true)
+}
+
+func TestInMemorySessionStoreCloseStopsReaperAndClosesSessions(t *testing.T) {
+	store := NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{
+		IdleTTL:      time.Hour,
+		ReapInterval: time.Minute,
+		MaxSessions:  4,
+	})
+	session := newSessionStoreTestSession(t, "shutdown")
+	if err := store.Store(context.Background(), session.ID(), session); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("second close was not idempotent: %v", err)
+	}
+
+	select {
+	case <-store.done:
+	case <-time.After(time.Second):
+		t.Fatal("reaper did not stop")
+	}
+	waitForSessionClose(t, session, time.Second)
+
+	err := store.Store(context.Background(), "after-close", newSessionStoreTestSession(t, "after-close"))
+	if !errors.Is(err, ErrSessionStoreClosed) {
+		t.Fatalf("expected ErrSessionStoreClosed, got %v", err)
+	}
+}
+
+func TestHTTPServerReturnsServiceUnavailableAtSessionCapacity(t *testing.T) {
+	store := NewInMemorySessionStoreWithOptions(InMemorySessionStoreOptions{
+		IdleTTL:      time.Hour,
+		ReapInterval: time.Minute,
+		MaxSessions:  1,
+	})
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close session store: %v", err)
+		}
+	})
+
+	blocking := newSessionStoreTestSession(t, "blocking")
+	if err := store.Store(context.Background(), blocking.ID(), blocking); err != nil {
+		t.Fatal(err)
+	}
+
+	var handlerCalls int32
+	handler := MessageHandlerFunc(func(ctx context.Context, msg Message) {
+		atomic.AddInt32(&handlerCalls, 1)
+		if err := msg.Reply(ctx, InitializeResult{
+			ProtocolVersion: "2025-06-18",
+			ServerInfo: ServerInfo{
+				Name:    "test",
+				Version: "1",
+			},
+		}); err != nil {
+			t.Errorf("reply to initialize: %v", err)
+		}
+	})
+	server, err := NewHTTPServer(nil, handler, HTTPServerOptions{SessionStore: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.test/mcp", bytes.NewBufferString(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+	))
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusServiceUnavailable, recorder.Code, recorder.Body.String())
+	}
+	if retryAfter := recorder.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatal("capacity response did not include Retry-After")
+	}
+	if got := atomic.LoadInt32(&handlerCalls); got != 0 {
+		t.Fatalf("initialize handler ran %d times despite capacity rejection", got)
+	}
+}
+
+func storeSessionThenRelease(t *testing.T, store *InMemorySessionStore, session *ServerSession) {
+	t.Helper()
+	if err := store.Store(context.Background(), session.ID(), session); err != nil {
+		t.Fatal(err)
+	}
+	store.Release(session)
+}
+
+func newSessionStoreTestSession(t *testing.T, id string) *ServerSession {
+	t.Helper()
+	session, err := NewExistingServerSession(
+		context.Background(),
+		SessionState{ID: id},
+		MessageHandlerFunc(func(context.Context, Message) {}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if session.GetSession().IsActive() {
+			session.Close(true)
+		}
+	})
+	return session
+}
+
+func waitForSessionClose(t *testing.T, session *ServerSession, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-session.GetSession().Context().Done():
+	case <-time.After(timeout):
+		t.Fatalf("session %q was not closed within %s", session.ID(), timeout)
+	}
+}

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -21,32 +21,82 @@ import (
 
 const defaultGarbageCollectionInterval = time.Hour
 
+const (
+	DefaultLiveSessionIdleTTL = 10 * time.Second
+	DefaultMaxLiveSessions    = 4
+)
+
+// ManagerOptions configures persisted-session garbage collection and the
+// bounded set of live sessions that may own downstream resources.
+type ManagerOptions struct {
+	DatabaseGarbageCollectionPeriod time.Duration
+	LiveSessionIdleTTL              time.Duration
+	MaxLiveSessions                 int
+}
+
+func (o ManagerOptions) Complete() ManagerOptions {
+	if o.LiveSessionIdleTTL <= 0 {
+		o.LiveSessionIdleTTL = DefaultLiveSessionIdleTTL
+	}
+	if o.MaxLiveSessions <= 0 {
+		o.MaxLiveSessions = DefaultMaxLiveSessions
+	}
+	return o
+}
+
 func NewManager(ctx context.Context, store *Store, gcPeriod time.Duration) *Manager {
+	return NewManagerWithOptions(ctx, store, ManagerOptions{
+		DatabaseGarbageCollectionPeriod: gcPeriod,
+	})
+}
+
+func NewManagerWithOptions(ctx context.Context, store *Store, opts ManagerOptions) *Manager {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	opts = opts.Complete()
+
 	m := &Manager{
-		ctx:          ctx,
-		DB:           store,
-		root:         &Session{},
-		liveSessions: make(map[string]liveSession),
+		ctx:                ctx,
+		cancel:             cancel,
+		done:               make(chan struct{}),
+		DB:                 store,
+		root:               &Session{},
+		liveSessions:       make(map[string]liveSession),
+		liveSessionIdleTTL: opts.LiveSessionIdleTTL,
+		maxLiveSessions:    opts.MaxLiveSessions,
+		newServerSession: func(ctx context.Context, state mcp.SessionState, server mcp.MessageHandler) (*mcp.ServerSession, error) {
+			return mcp.NewExistingServerSession(ctx, state, server)
+		},
 	}
 
-	m.startGarbageCollector(gcPeriod)
+	m.startGarbageCollector(opts.DatabaseGarbageCollectionPeriod)
+	go m.closeOnShutdown()
 
 	return m
 }
 
 type Manager struct {
-	ctx  context.Context
-	DB   *Store
-	root *Session
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+	DB     *Store
+	root   *Session
 
-	liveSessionsLock sync.Mutex
-	liveSessions     map[string]liveSession
+	liveSessionsLock   sync.Mutex
+	liveSessions       map[string]liveSession
+	pendingSessions    int
+	liveSessionIdleTTL time.Duration
+	maxLiveSessions    int
+	newServerSession   func(context.Context, mcp.SessionState, mcp.MessageHandler) (*mcp.ServerSession, error)
 }
 
 type liveSession struct {
-	session *mcp.ServerSession
-	count   int
-	cancel  context.CancelFunc
+	session  *mcp.ServerSession
+	count    int
+	cancel   context.CancelFunc
+	lastUsed time.Time
 }
 
 func (m *Manager) newRecord(id, accountID string) *Session {
@@ -117,24 +167,12 @@ func (m *Manager) Store(ctx context.Context, id string, session *mcp.ServerSessi
 		if err := m.DB.Create(ctx, stored); err != nil {
 			return fmt.Errorf("failed to create session record: %w", err)
 		}
-
-		m.liveSessionsLock.Lock()
-		live, ok := m.liveSessions[id]
-		if ok {
-			if live.session != nil {
-				live.session.Close(false)
+		if err := m.addLiveSession(session); err != nil {
+			if deleteErr := m.DB.Delete(ctx, id); deleteErr != nil && !errors.Is(deleteErr, gorm.ErrRecordNotFound) {
+				slog.Error("failed to remove rejected session record", "session_id", id, "error", deleteErr)
 			}
-			live.count++
-			live.session = session
-
-			m.liveSessions[id] = live
-		} else {
-			m.liveSessions[id] = liveSession{
-				session: session,
-				count:   1,
-			}
+			return err
 		}
-		m.liveSessionsLock.Unlock()
 	} else {
 		if err := m.DB.Update(ctx, stored); err != nil {
 			return err
@@ -143,6 +181,122 @@ func (m *Manager) Store(ctx context.Context, id string, session *mcp.ServerSessi
 
 	m.loadAttributesFromRecord(stored, session)
 	return nil
+}
+
+func (m *Manager) Reserve(ctx context.Context) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var evicted *mcp.ServerSession
+	m.liveSessionsLock.Lock()
+	if err := m.ctx.Err(); err != nil {
+		m.liveSessionsLock.Unlock()
+		return nil, mcp.ErrSessionStoreClosed
+	}
+
+	if len(m.liveSessions)+m.pendingSessions >= m.maxLiveSessions {
+		evictionID, candidate := m.leastRecentlyUsedIdleSessionLocked()
+		if candidate == nil {
+			err := &mcp.SessionCapacityError{
+				MaxSessions:     m.maxLiveSessions,
+				ActiveSessions:  len(m.liveSessions),
+				PendingSessions: m.pendingSessions,
+			}
+			m.liveSessionsLock.Unlock()
+			return nil, err
+		}
+		delete(m.liveSessions, evictionID)
+		if candidate.cancel != nil {
+			candidate.cancel()
+		}
+		evicted = candidate.session
+		slog.Info("evicting idle live session to reserve capacity",
+			"session_id", evictionID,
+			"max_live_sessions", m.maxLiveSessions)
+	}
+
+	m.pendingSessions++
+	m.liveSessionsLock.Unlock()
+
+	if evicted != nil {
+		evicted.Close(true)
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.liveSessionsLock.Lock()
+			if m.pendingSessions > 0 {
+				m.pendingSessions--
+			}
+			m.liveSessionsLock.Unlock()
+		})
+	}, nil
+}
+
+func (m *Manager) addLiveSession(session *mcp.ServerSession) error {
+	var evicted *mcp.ServerSession
+
+	m.liveSessionsLock.Lock()
+	if err := m.ctx.Err(); err != nil {
+		m.liveSessionsLock.Unlock()
+		return mcp.ErrSessionStoreClosed
+	}
+	if _, exists := m.liveSessions[session.ID()]; exists {
+		m.liveSessionsLock.Unlock()
+		return fmt.Errorf("live session %q already exists", session.ID())
+	}
+	if len(m.liveSessions) >= m.maxLiveSessions {
+		evictionID, candidate := m.leastRecentlyUsedIdleSessionLocked()
+		if candidate == nil {
+			err := &mcp.SessionCapacityError{
+				MaxSessions:     m.maxLiveSessions,
+				ActiveSessions:  len(m.liveSessions),
+				PendingSessions: m.pendingSessions,
+			}
+			m.liveSessionsLock.Unlock()
+			return err
+		}
+		delete(m.liveSessions, evictionID)
+		if candidate.cancel != nil {
+			candidate.cancel()
+		}
+		evicted = candidate.session
+		slog.Info("evicting idle live session at capacity",
+			"session_id", evictionID,
+			"max_live_sessions", m.maxLiveSessions)
+	}
+
+	m.liveSessions[session.ID()] = liveSession{
+		session:  session,
+		count:    1,
+		lastUsed: time.Now(),
+	}
+	m.liveSessionsLock.Unlock()
+
+	if evicted != nil {
+		evicted.Close(true)
+	}
+	return nil
+}
+
+func (m *Manager) leastRecentlyUsedIdleSessionLocked() (string, *liveSession) {
+	var (
+		evictionID string
+		eviction   *liveSession
+	)
+	for id, candidate := range m.liveSessions {
+		if candidate.count != 0 {
+			continue
+		}
+		if eviction == nil || candidate.lastUsed.Before(eviction.lastUsed) {
+			copy := candidate
+			evictionID = id
+			eviction = &copy
+		}
+	}
+	return evictionID, eviction
 }
 
 func (m *Manager) ExtractID(req *http.Request) string {
@@ -182,6 +336,10 @@ func (m *Manager) Acquire(ctx context.Context, server mcp.MessageHandler, id str
 	if ok {
 		select {
 		case <-live.session.GetSession().Context().Done():
+			delete(m.liveSessions, id)
+			if live.cancel != nil {
+				live.cancel()
+			}
 			m.liveSessionsLock.Unlock()
 			return nil, false, nil
 		default:
@@ -198,11 +356,18 @@ func (m *Manager) Acquire(ctx context.Context, server mcp.MessageHandler, id str
 		}
 
 		live.count++
+		live.lastUsed = time.Now()
 		m.liveSessions[id] = live
 		m.liveSessionsLock.Unlock()
 		return live.session, true, nil
 	}
 	m.liveSessionsLock.Unlock()
+
+	releaseReservation, err := m.Reserve(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer releaseReservation()
 
 	serverSession, ok, err := m.loadSessionFromDatabase(ctx, server, id)
 	if err != nil || !ok {
@@ -210,58 +375,94 @@ func (m *Manager) Acquire(ctx context.Context, server mcp.MessageHandler, id str
 	}
 
 	if !checkAccount(ctx, serverSession) {
+		serverSession.Close(true)
 		return nil, false, nil
 	}
 
+	var evicted *mcp.ServerSession
 	m.liveSessionsLock.Lock()
 	live, ok = m.liveSessions[id]
 	if ok {
-		serverSession.Close(false)
+		serverSession.Close(true)
+		if !checkAccount(ctx, live.session) {
+			m.liveSessionsLock.Unlock()
+			return nil, false, nil
+		}
 		if live.cancel != nil {
 			live.cancel()
 			live.cancel = nil
 		}
 		live.count++
+		live.lastUsed = time.Now()
 		m.liveSessions[id] = live
 		m.liveSessionsLock.Unlock()
 		return live.session, true, nil
 	}
+	if len(m.liveSessions) >= m.maxLiveSessions {
+		evictionID, candidate := m.leastRecentlyUsedIdleSessionLocked()
+		if candidate == nil {
+			err := &mcp.SessionCapacityError{
+				MaxSessions:     m.maxLiveSessions,
+				ActiveSessions:  len(m.liveSessions),
+				PendingSessions: m.pendingSessions,
+			}
+			m.liveSessionsLock.Unlock()
+			serverSession.Close(true)
+			return nil, false, err
+		}
+		delete(m.liveSessions, evictionID)
+		if candidate.cancel != nil {
+			candidate.cancel()
+		}
+		evicted = candidate.session
+	}
 	m.liveSessions[id] = liveSession{
-		session: serverSession,
-		count:   1,
+		session:  serverSession,
+		count:    1,
+		lastUsed: time.Now(),
 	}
 	m.liveSessionsLock.Unlock()
 
+	if evicted != nil {
+		evicted.Close(true)
+	}
 	return serverSession, true, err
 }
 
 func (m *Manager) Release(session *mcp.ServerSession) {
 	m.liveSessionsLock.Lock()
-	defer m.liveSessionsLock.Unlock()
 
 	live, ok := m.liveSessions[session.ID()]
-	if ok {
-		live.count--
+	if ok && live.session == session {
 		if live.count == 0 {
-			ctx, cancel := context.WithCancel(context.Background())
+			m.liveSessionsLock.Unlock()
+			return
+		}
+		live.count--
+		live.lastUsed = time.Now()
+		if live.count == 0 {
+			ctx, cancel := context.WithCancel(m.ctx)
 			live.cancel = cancel
 
 			go func(ctx context.Context, sessionID string) {
 				defer cancel()
+				timer := time.NewTimer(m.liveSessionIdleTTL)
+				defer timer.Stop()
 				select {
 				case <-ctx.Done():
 					return
-				case <-time.After(10 * time.Second):
+				case <-timer.C:
 				}
 
 				m.liveSessionsLock.Lock()
-				defer m.liveSessionsLock.Unlock()
-
 				live, ok := m.liveSessions[sessionID]
 				if ok && live.count == 0 {
 					delete(m.liveSessions, sessionID)
-					live.session.Close(false)
+					m.liveSessionsLock.Unlock()
+					live.session.Close(true)
+					return
 				}
+				m.liveSessionsLock.Unlock()
 			}(ctx, session.ID())
 		} else if live.cancel != nil {
 			live.cancel()
@@ -269,8 +470,10 @@ func (m *Manager) Release(session *mcp.ServerSession) {
 		}
 
 		m.liveSessions[session.ID()] = live
+		m.liveSessionsLock.Unlock()
 	} else {
-		session.Close(false)
+		m.liveSessionsLock.Unlock()
+		session.Close(true)
 	}
 }
 
@@ -334,8 +537,7 @@ func (m *Manager) loadSessionFromDatabase(ctx context.Context, server mcp.Messag
 		storedSession.State.Attributes[".keys"] = slices.Collect(maps.Keys(storedSession.State.Attributes))
 	}
 
-	serverSession, err := mcp.NewExistingServerSession(m.ctx,
-		mcp.SessionState(storedSession.State), server)
+	serverSession, err := m.newServerSession(m.ctx, mcp.SessionState(storedSession.State), server)
 	if err != nil {
 		return nil, false, err
 	}
@@ -349,13 +551,50 @@ func (m *Manager) LoadAndDelete(ctx context.Context, server mcp.MessageHandler, 
 	if !found || err != nil {
 		return session, found, err
 	}
-	defer m.Release(session)
+
+	m.liveSessionsLock.Lock()
+	if live, ok := m.liveSessions[id]; ok && live.session == session {
+		delete(m.liveSessions, id)
+		if live.cancel != nil {
+			live.cancel()
+		}
+	}
+	m.liveSessionsLock.Unlock()
 
 	err = m.DB.Delete(ctx, id)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
+		session.Close(true)
 		return nil, false, nil
 	} else if err != nil {
+		session.Close(true)
 		return nil, false, fmt.Errorf("failed to delete session: %w", err)
 	}
 	return session, true, nil
+}
+
+func (m *Manager) Close() error {
+	m.cancel()
+	<-m.done
+	return nil
+}
+
+func (m *Manager) closeOnShutdown() {
+	defer close(m.done)
+	<-m.ctx.Done()
+
+	var sessions []*mcp.ServerSession
+	m.liveSessionsLock.Lock()
+	sessions = make([]*mcp.ServerSession, 0, len(m.liveSessions))
+	for id, live := range m.liveSessions {
+		delete(m.liveSessions, id)
+		if live.cancel != nil {
+			live.cancel()
+		}
+		sessions = append(sessions, live.session)
+	}
+	m.liveSessionsLock.Unlock()
+
+	for _, session := range sessions {
+		session.Close(true)
+	}
 }

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -1,0 +1,293 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/nanobot/pkg/mcp"
+	"github.com/obot-platform/nanobot/pkg/types"
+)
+
+func TestHTTPServerReconnectStormBoundsLiveSessionResources(t *testing.T) {
+	manager := NewManagerWithOptions(context.Background(), newTestStore(t), ManagerOptions{
+		LiveSessionIdleTTL: time.Hour,
+		MaxLiveSessions:    1,
+	})
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Errorf("close manager: %v", err)
+		}
+	})
+
+	var (
+		activeChildren int32
+		maxChildren    int32
+		handlerCalls   int32
+	)
+	firstStarted := make(chan struct{})
+	unblockFirst := make(chan struct{})
+	handler := mcp.MessageHandlerFunc(func(ctx context.Context, msg mcp.Message) {
+		atomic.AddInt32(&handlerCalls, 1)
+		active := atomic.AddInt32(&activeChildren, 1)
+		updateAtomicMax(&maxChildren, active)
+		msg.Session.Set("test-child", &countingSessionResource{active: &activeChildren})
+		close(firstStarted)
+		<-unblockFirst
+		if err := msg.Reply(ctx, testInitializeResult()); err != nil {
+			t.Errorf("reply to initialize: %v", err)
+		}
+	})
+
+	server, err := mcp.NewHTTPServer(nil, handler, mcp.HTTPServerOptions{
+		SessionStore: manager,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const requests = 10
+	results := make(chan int, requests)
+	for range requests {
+		go func() {
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, newInitializeRequest())
+			results <- recorder.Code
+		}()
+	}
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first initialization did not start")
+	}
+
+	for range requests - 1 {
+		select {
+		case status := <-results:
+			if status != http.StatusServiceUnavailable {
+				t.Fatalf("reconnect storm status = %d, want %d", status, http.StatusServiceUnavailable)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("reconnect request was not rejected before creating a session")
+		}
+	}
+
+	close(unblockFirst)
+	select {
+	case status := <-results:
+		if status != http.StatusOK {
+			t.Fatalf("admitted initialization status = %d, want %d", status, http.StatusOK)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("admitted initialization did not finish")
+	}
+
+	if got := atomic.LoadInt32(&handlerCalls); got != 1 {
+		t.Fatalf("handler calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&maxChildren); got != 1 {
+		t.Fatalf("maximum concurrent downstream resources = %d, want 1", got)
+	}
+
+	if err := manager.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&activeChildren); got != 0 {
+		t.Fatalf("active downstream resources after shutdown = %d, want 0", got)
+	}
+}
+
+func TestHTTPServerEventStreamLifetimeReleasesLiveSession(t *testing.T) {
+	manager := NewManagerWithOptions(context.Background(), newTestStore(t), ManagerOptions{
+		LiveSessionIdleTTL: 20 * time.Millisecond,
+		MaxLiveSessions:    1,
+	})
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Errorf("close manager: %v", err)
+		}
+	})
+
+	var activeChildren int32
+	handler := mcp.MessageHandlerFunc(func(ctx context.Context, msg mcp.Message) {
+		atomic.AddInt32(&activeChildren, 1)
+		msg.Session.Set("test-child", &countingSessionResource{active: &activeChildren})
+		if err := msg.Reply(ctx, testInitializeResult()); err != nil {
+			t.Errorf("reply to initialize: %v", err)
+		}
+	})
+	server, err := mcp.NewHTTPServer(nil, handler, mcp.HTTPServerOptions{
+		SessionStore:           manager,
+		EventStreamMaxLifetime: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initializeRecorder := httptest.NewRecorder()
+	server.ServeHTTP(initializeRecorder, newInitializeRequest())
+	if initializeRecorder.Code != http.StatusOK {
+		t.Fatalf("initialize status = %d: %s", initializeRecorder.Code, initializeRecorder.Body.String())
+	}
+	sessionID := initializeRecorder.Header().Get("Mcp-Session-Id")
+	if sessionID == "" {
+		t.Fatal("initialize response did not include a session ID")
+	}
+
+	streamRequest := httptest.NewRequest(http.MethodGet, "http://example.test/mcp", nil)
+	streamRequest.Header.Set("Mcp-Session-Id", sessionID)
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		server.ServeHTTP(httptest.NewRecorder(), streamRequest)
+	}()
+
+	select {
+	case <-streamDone:
+	case <-time.After(time.Second):
+		t.Fatal("event stream exceeded its configured maximum lifetime")
+	}
+
+	deadline := time.After(time.Second)
+	for atomic.LoadInt32(&activeChildren) != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("session resource remained active after stream lifetime and idle TTL elapsed")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func TestManagerReserveEvictsIdleSessionAtCapacity(t *testing.T) {
+	manager := NewManagerWithOptions(context.Background(), newTestStore(t), ManagerOptions{
+		LiveSessionIdleTTL: time.Hour,
+		MaxLiveSessions:    1,
+	})
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Errorf("close manager: %v", err)
+		}
+	})
+
+	var activeChildren int32 = 1
+	session := newManagerTestSession(t, "idle")
+	session.GetSession().Set("test-child", &countingSessionResource{active: &activeChildren})
+	if err := manager.Store(context.Background(), session.ID(), session); err != nil {
+		t.Fatal(err)
+	}
+	manager.Release(session)
+
+	release, err := manager.Reserve(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+
+	select {
+	case <-session.GetSession().Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("idle session was not closed when capacity was reserved")
+	}
+	if got := atomic.LoadInt32(&activeChildren); got != 0 {
+		t.Fatalf("active downstream resources = %d, want 0", got)
+	}
+}
+
+func TestManagerAcquireClosesLoadedSessionOnAccountMismatch(t *testing.T) {
+	store := newTestStore(t)
+	createTestSession(t, store, "other-account", time.Now())
+
+	manager := NewManagerWithOptions(context.Background(), store, ManagerOptions{})
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Errorf("close manager: %v", err)
+		}
+	})
+
+	var loaded *mcp.ServerSession
+	newServerSession := manager.newServerSession
+	manager.newServerSession = func(ctx context.Context, state mcp.SessionState, server mcp.MessageHandler) (*mcp.ServerSession, error) {
+		session, err := newServerSession(ctx, state, server)
+		loaded = session
+		return session, err
+	}
+
+	ctx := types.WithNanobotContext(context.Background(), types.Context{
+		User: mcp.User{ID: "not-account-1"},
+	})
+	session, found, err := manager.Acquire(ctx, mcp.MessageHandlerFunc(func(context.Context, mcp.Message) {}), "other-account")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found || session != nil {
+		t.Fatal("session from another account was returned")
+	}
+	if loaded == nil {
+		t.Fatal("persisted session was not loaded")
+	}
+	select {
+	case <-loaded.GetSession().Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("rejected loaded session was not closed")
+	}
+}
+
+type countingSessionResource struct {
+	active *int32
+	once   sync.Once
+}
+
+func (r *countingSessionResource) Close(bool) {
+	r.once.Do(func() {
+		atomic.AddInt32(r.active, -1)
+	})
+}
+
+func newInitializeRequest() *http.Request {
+	return httptest.NewRequest(http.MethodPost, "http://example.test/mcp", bytes.NewBufferString(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+	))
+}
+
+func testInitializeResult() mcp.InitializeResult {
+	return mcp.InitializeResult{
+		ProtocolVersion: "2025-06-18",
+		ServerInfo: mcp.ServerInfo{
+			Name:    "test",
+			Version: "1",
+		},
+	}
+}
+
+func newManagerTestSession(t *testing.T, id string) *mcp.ServerSession {
+	t.Helper()
+	session, err := mcp.NewExistingServerSession(
+		context.Background(),
+		mcp.SessionState{ID: id},
+		mcp.MessageHandlerFunc(func(context.Context, mcp.Message) {}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if session.GetSession().IsActive() {
+			session.Close(true)
+		}
+	})
+	return session
+}
+
+func updateAtomicMax(target *int32, candidate int32) {
+	for {
+		current := atomic.LoadInt32(target)
+		if candidate <= current || atomic.CompareAndSwapInt32(target, current, candidate) {
+			return
+		}
+	}
+}

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -247,7 +247,7 @@ func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
 	}
 
 	if c.client != nil {
-		c.client.Close(false)
+		c.client.Close(true)
 		c.client = nil
 	}
 
@@ -258,6 +258,20 @@ func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
 	c.client = newClient
 	c.envHash = envHash
 	return c.client, nil
+}
+
+// Close releases the live client, sending a DELETE to the upstream MCP server
+// so its session is freed and its reader goroutine stops. A factory is only
+// closed when its client is being permanently discarded (session teardown or
+// config refresh); the upstream session will not be resumed, so it is always
+// deleted regardless of the caller's deleteSession hint.
+func (c *clientFactory) Close(bool) {
+	c.clientLock.Lock()
+	defer c.clientLock.Unlock()
+	if c.client != nil {
+		c.client.Close(true)
+		c.client = nil
+	}
 }
 
 func (c *clientFactory) Serialize() (any, error) {

--- a/pkg/tools/service_leak_test.go
+++ b/pkg/tools/service_leak_test.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/obot-platform/nanobot/pkg/mcp"
+)
+
+// fakeMCPServer is a minimal Streamable-HTTP MCP server that completes the
+// initialize handshake and records DELETE (session termination) requests.
+func fakeMCPServer(deletes *int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			atomic.AddInt32(deletes, 1)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var msg struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(body, &msg)
+			if msg.Method == "initialize" {
+				w.Header().Set("Mcp-Session-Id", "test-session-1")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + string(msg.ID) +
+					`,"result":{"protocolVersion":"2025-06-18","capabilities":{},` +
+					`"serverInfo":{"name":"fake","version":"1"}}}`))
+				return
+			}
+			// notifications/initialized and anything else
+			w.WriteHeader(http.StatusAccepted)
+		case http.MethodGet:
+			// SSE event stream is unused in this test
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+// Compile-time assert the factory is closable so session teardown reaps it.
+var _ interface{ Close(bool) } = (*clientFactory)(nil)
+
+// TestClientFactoryCloseDeletesUpstreamSession proves that closing a
+// clientFactory terminates the upstream MCP session (sends DELETE), preventing
+// the per-reconnect session leak observed against downstream MCP servers.
+func TestClientFactoryCloseDeletesUpstreamSession(t *testing.T) {
+	var deletes int32
+	srv := fakeMCPServer(&deletes)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := mcp.NewClient(ctx, "grocy", mcp.Server{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	f := newClientFactory(func(*mcp.SessionState) (*mcp.Client, error) {
+		return client, nil
+	})
+	if _, err := f.get("envhash"); err != nil {
+		t.Fatalf("factory.get failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&deletes); got != 0 {
+		t.Fatalf("expected no DELETE before close, got %d", got)
+	}
+
+	f.Close(false)
+
+	if got := atomic.LoadInt32(&deletes); got != 1 {
+		t.Fatalf("expected exactly one upstream DELETE after factory close, got %d", got)
+	}
+}

--- a/pkg/tools/service_leak_test.go
+++ b/pkg/tools/service_leak_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/nanobot/pkg/mcp"
 )
@@ -26,11 +27,20 @@ func fakeMCPServer(deletes *int32) *httptest.Server {
 				ID     json.RawMessage `json:"id"`
 				Method string          `json:"method"`
 			}
-			_ = json.Unmarshal(body, &msg)
+			if err := json.Unmarshal(body, &msg); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 			if msg.Method == "initialize" {
+				// Always emit a valid JSON-RPC id; default to null if the
+				// request omitted one so the response can never be malformed.
+				id := string(msg.ID)
+				if id == "" {
+					id = "null"
+				}
 				w.Header().Set("Mcp-Session-Id", "test-session-1")
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + string(msg.ID) +
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + id +
 					`,"result":{"protocolVersion":"2025-06-18","capabilities":{},` +
 					`"serverInfo":{"name":"fake","version":"1"}}}`))
 				return
@@ -76,6 +86,14 @@ func TestClientFactoryCloseDeletesUpstreamSession(t *testing.T) {
 
 	f.Close(false)
 
+	// Close sends the upstream DELETE synchronously today, but poll so the test
+	// stays correct even if client teardown ever becomes asynchronous. A
+	// trailing settle confirms exactly one DELETE is sent (no duplicates).
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&deletes) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
 	if got := atomic.LoadInt32(&deletes); got != 1 {
 		t.Fatalf("expected exactly one upstream DELETE after factory close, got %d", got)
 	}


### PR DESCRIPTION
## Status

Draft integration of the downstream-client cleanup from #325 with hard session-lifecycle bounds. The two #325 commits are preserved with their original author and unchanged intent; this PR is not intended to erase or compete with that work.

## Problem

A reconnect storm can create several live HTTP sessions before idle teardown runs. Each session may own a downstream MCP client and, for stdio servers, a separate process tree.

Three independent gaps make the failure unbounded:

1. session teardown did not close downstream client factories (#325)
2. live and in-memory session stores had no hard capacity
3. an SSE reference could hold a session indefinitely

Increasing a container memory limit only delays the same linear growth.

## Changes

### Downstream cleanup

Includes #325:

- close closable session attributes
- make `clientFactory` closable
- delete permanently discarded upstream sessions

### Live-session bounds

- default maximum of four live sessions
- reserve capacity before initialize creates downstream resources
- never evict an acquired session
- evict only the least-recently-used idle session
- return retryable HTTP 503 with `Retry-After` when all capacity is active
- close idle live sessions after ten seconds
- cap one SSE stream lifetime at five minutes so stale references eventually release
- close restored sessions rejected by account checks
- close all live resources on manager shutdown

Runtime controls:

- `--max-live-sessions` / `NANOBOT_MAX_LIVE_SESSIONS`
- `--live-session-idle-ttl` / `NANOBOT_LIVE_SESSION_IDLE_TTL`
- `--event-stream-max-lifetime` / `NANOBOT_EVENT_STREAM_MAX_LIFETIME`

### Generic store bounds

The default in-memory store now has:

- refcounted acquire/release
- idle TTL
- maximum capacity
- idle LRU eviction
- clean reaper shutdown

### Race fix

`HTTPClient.initialize` no longer shares the named `err` variable between the SSE goroutine and response reader. A synchronized regression test reproduces this under the race detector.

## Verification

- reconnect storm test: ten concurrent initialize requests create one downstream resource; the remaining requests fail before handler execution
- stale SSE lifetime and idle release test
- acquired-session non-eviction and idle LRU tests
- account-mismatch cleanup test
- repeated race-focused tests
- changed packages pass with `-race`
- `go vet ./...`
- `go test ./... -count=1` on the exact branch

## Relationship to other work

- #325 is the root downstream-resource cleanup and is included with attribution.
- #346 adds reconnect backoff; it is complementary and not duplicated here.
- capacity and lifetime limits remain useful even after cleanup and backoff, because they make resource use fail closed under unexpected clients or transport failures.

I am happy to split the generic store, race fix, and live-manager changes into separate PRs, or to retarget these commits onto #325, depending on maintainer preference.
