### PR TITLE
feat: refresh MiniMax model configuration

### DIFF
--- a/pkg/agents/compact.go
+++ b/pkg/agents/compact.go
@@ -17,11 +17,19 @@ const (
 	defaultContextWindow     = 200_000
 )
 
-// getContextWindowSize returns the context window size for the given model.
-// If configOverride is > 0, it is used directly. Otherwise, defaults to 200k.
-func getContextWindowSize(configOverride int) int {
+type contextWindowProvider interface {
+	ContextWindow(model string) int
+}
+
+// getContextWindowSize returns the configured or registered context window size.
+func getContextWindowSize(configOverride int, model string, completer types.Completer) int {
 	if configOverride > 0 {
 		return configOverride
+	}
+	if provider, ok := completer.(contextWindowProvider); ok {
+		if contextWindow := provider.ContextWindow(model); contextWindow > 0 {
+			return contextWindow
+		}
 	}
 	return defaultContextWindow
 }

--- a/pkg/agents/compact_test.go
+++ b/pkg/agents/compact_test.go
@@ -3,19 +3,35 @@ package agents
 import (
 	"testing"
 
+	"github.com/obot-platform/nanobot/pkg/llm"
 	"github.com/obot-platform/nanobot/pkg/mcp"
 	"github.com/obot-platform/nanobot/pkg/types"
 )
 
 func TestGetContextWindowSize_ConfigOverride(t *testing.T) {
-	size := getContextWindowSize(50000)
+	size := getContextWindowSize(50000, "minimax/MiniMax-M3", nil)
 	if size != 50000 {
 		t.Errorf("expected config override 50000, got %d", size)
 	}
 }
 
+func TestGetContextWindowSize_ModelConfig(t *testing.T) {
+	client := llm.NewClient(llm.Config{
+		Models: map[string]map[string]llm.ModelConfig{
+			"minimax": {
+				"MiniMax-M3": {ContextWindow: 1_000_000},
+			},
+		},
+	})
+
+	size := getContextWindowSize(0, "minimax/MiniMax-M3", client)
+	if size != 1_000_000 {
+		t.Errorf("expected registered context window 1000000, got %d", size)
+	}
+}
+
 func TestGetContextWindowSize_Default(t *testing.T) {
-	size := getContextWindowSize(0)
+	size := getContextWindowSize(0, "minimax/unknown", nil)
 	if size != defaultContextWindow {
 		t.Errorf("expected default %d, got %d", defaultContextWindow, size)
 	}

--- a/pkg/agents/run.go
+++ b/pkg/agents/run.go
@@ -610,7 +610,7 @@ func (a *Agents) run(ctx context.Context, config types.Config, run *types.Execut
 	// Check if compaction is needed
 	agent, agentExists := config.Agents[completionRequest.GetAgent()]
 	if agentExists {
-		ctxWindowSize := getContextWindowSize(agent.ContextWindow)
+		ctxWindowSize := getContextWindowSize(agent.ContextWindow, completionRequest.Model, a.completer)
 		if shouldCompact(completionRequest, ctxWindowSize) {
 			var prevCompacted []types.Message
 			if prev != nil {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -159,6 +159,7 @@ func display(obj any, format string) bool {
 }
 
 func (n *Nanobot) llmConfig() llm.Config {
+	cacheWrite := 0.375
 	return llm.Config{
 		DefaultModel:     n.DefaultModel,
 		DefaultMiniModel: n.DefaultMiniModel,
@@ -174,6 +175,53 @@ func (n *Nanobot) llmConfig() llm.Config {
 				Dialect: types.DialectAnthropicMessages,
 				APIKey:  "${ANTHROPIC_API_KEY}",
 				BaseURL: "${ANTHROPIC_BASE_URL}",
+			},
+			"minimax": {
+				Dialect: types.DialectOpenAIChatCompletions,
+				APIKey:  "${MINIMAX_API_KEY}",
+				BaseURL: "${MINIMAX_BASE_URL}",
+				Region:  "${MINIMAX_REGION}",
+			},
+		},
+		ProviderEndpoints: map[string][]llm.ProviderEndpoint{
+			"minimax": {
+				{
+					Region:           "global_en",
+					OpenAIBaseURL:    "https://api.minimax.io/v1",
+					AnthropicBaseURL: "https://api.minimax.io/anthropic",
+					DocsRoot:         "https://platform.minimax.io/docs",
+				},
+				{
+					Region:           "cn_zh",
+					OpenAIBaseURL:    "https://api.minimaxi.com/v1",
+					AnthropicBaseURL: "https://api.minimaxi.com/anthropic",
+					DocsRoot:         "https://platform.minimaxi.com/docs",
+				},
+			},
+		},
+		Models: map[string]map[string]llm.ModelConfig{
+			"minimax": {
+				"MiniMax-M3": {
+					ContextWindow: 1_000_000,
+					Pricing: llm.ModelPricing{
+						Input:     0.6,
+						Output:    2.4,
+						CacheRead: 0.12,
+					},
+					InputModalities: []string{"text", "image", "video"},
+					Thinking:        []string{"adaptive", "disabled"},
+				},
+				"MiniMax-M2.7": {
+					ContextWindow: 204_800,
+					Pricing: llm.ModelPricing{
+						Input:      0.3,
+						Output:     1.2,
+						CacheRead:  0.06,
+						CacheWrite: &cacheWrite,
+					},
+					InputModalities: []string{"text"},
+					Thinking:        []string{"always_on"},
+				},
 			},
 		},
 	}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -3,10 +3,59 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/obot-platform/nanobot/pkg/config"
+	"github.com/obot-platform/nanobot/pkg/types"
 )
+
+func TestNanobotLLMConfigIncludesMiniMax(t *testing.T) {
+	cfg := (&Nanobot{}).llmConfig()
+	provider, ok := cfg.LLMProviders["minimax"]
+	if !ok {
+		t.Fatal("expected MiniMax provider config")
+	}
+	if provider.Dialect != types.DialectOpenAIChatCompletions {
+		t.Fatalf("expected MiniMax dialect %q, got %q", types.DialectOpenAIChatCompletions, provider.Dialect)
+	}
+	if provider.APIKey != "${MINIMAX_API_KEY}" {
+		t.Fatalf("unexpected MiniMax API key placeholder: %q", provider.APIKey)
+	}
+	if provider.BaseURL != "${MINIMAX_BASE_URL}" {
+		t.Fatalf("unexpected MiniMax base URL: %q", provider.BaseURL)
+	}
+	if provider.Region != "${MINIMAX_REGION}" {
+		t.Fatalf("unexpected MiniMax region placeholder: %q", provider.Region)
+	}
+
+	endpoints := cfg.ProviderEndpoints["minimax"]
+	if len(endpoints) != 2 {
+		t.Fatalf("expected two MiniMax regional endpoints, got %d", len(endpoints))
+	}
+	if endpoints[0].Region != "global_en" || endpoints[0].OpenAIBaseURL != "https://api.minimax.io/v1" || endpoints[0].AnthropicBaseURL != "https://api.minimax.io/anthropic" || endpoints[0].DocsRoot != "https://platform.minimax.io/docs" {
+		t.Fatalf("unexpected MiniMax global endpoint: %+v", endpoints[0])
+	}
+	if endpoints[1].Region != "cn_zh" || endpoints[1].OpenAIBaseURL != "https://api.minimaxi.com/v1" || endpoints[1].AnthropicBaseURL != "https://api.minimaxi.com/anthropic" || endpoints[1].DocsRoot != "https://platform.minimaxi.com/docs" {
+		t.Fatalf("unexpected MiniMax China endpoint: %+v", endpoints[1])
+	}
+
+	m3 := cfg.Models["minimax"]["MiniMax-M3"]
+	if m3.ContextWindow != 1_000_000 || m3.Pricing.Input != 0.6 || m3.Pricing.Output != 2.4 || m3.Pricing.CacheRead != 0.12 || m3.Pricing.CacheWrite != nil {
+		t.Fatalf("unexpected MiniMax-M3 model config: %+v", m3)
+	}
+	if !slices.Equal(m3.InputModalities, []string{"text", "image", "video"}) || !slices.Equal(m3.Thinking, []string{"adaptive", "disabled"}) {
+		t.Fatalf("unexpected MiniMax-M3 capabilities: %+v", m3)
+	}
+
+	m27 := cfg.Models["minimax"]["MiniMax-M2.7"]
+	if m27.ContextWindow != 204_800 || m27.Pricing.Input != 0.3 || m27.Pricing.Output != 1.2 || m27.Pricing.CacheRead != 0.06 || m27.Pricing.CacheWrite == nil || *m27.Pricing.CacheWrite != 0.375 {
+		t.Fatalf("unexpected MiniMax-M2.7 model config: %+v", m27)
+	}
+	if !slices.Equal(m27.InputModalities, []string{"text"}) || !slices.Equal(m27.Thinking, []string{"always_on"}) {
+		t.Fatalf("unexpected MiniMax-M2.7 capabilities: %+v", m27)
+	}
+}
 
 func TestNanobotConfigPathsDefault(t *testing.T) {
 	n := &Nanobot{}

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/obot-platform/nanobot/pkg/complete"
@@ -25,12 +26,37 @@ type LLMProviderConfig struct {
 	Dialect types.Dialect
 	APIKey  string // supports ${VAR} syntax
 	BaseURL string // supports ${VAR} syntax
+	Region  string // supports ${VAR} syntax
 	Headers map[string]string
+}
+
+type ProviderEndpoint struct {
+	Region           string
+	OpenAIBaseURL    string
+	AnthropicBaseURL string
+	DocsRoot         string
+}
+
+// ModelPricing contains USD prices per million tokens.
+type ModelPricing struct {
+	Input      float64
+	Output     float64
+	CacheRead  float64
+	CacheWrite *float64
+}
+
+type ModelConfig struct {
+	ContextWindow   int
+	Pricing         ModelPricing
+	InputModalities []string
+	Thinking        []string
 }
 
 type Config struct {
 	DefaultModel, DefaultMiniModel string
 	LLMProviders                   map[string]LLMProviderConfig
+	ProviderEndpoints              map[string][]ProviderEndpoint
+	Models                         map[string]map[string]ModelConfig
 }
 
 func NewClient(cfg Config) *Client {
@@ -39,6 +65,31 @@ func NewClient(cfg Config) *Client {
 		defaultMiniModel: cfg.DefaultMiniModel,
 		cfg:              cfg,
 	}
+}
+
+func cloneProviderEndpoints(endpoints map[string][]ProviderEndpoint) map[string][]ProviderEndpoint {
+	result := make(map[string][]ProviderEndpoint, len(endpoints))
+	for provider, providerEndpoints := range endpoints {
+		result[provider] = slices.Clone(providerEndpoints)
+	}
+	return result
+}
+
+func cloneModels(models map[string]map[string]ModelConfig) map[string]map[string]ModelConfig {
+	result := make(map[string]map[string]ModelConfig, len(models))
+	for provider, providerModels := range models {
+		result[provider] = make(map[string]ModelConfig, len(providerModels))
+		for model, modelConfig := range providerModels {
+			modelConfig.InputModalities = slices.Clone(modelConfig.InputModalities)
+			modelConfig.Thinking = slices.Clone(modelConfig.Thinking)
+			if modelConfig.Pricing.CacheWrite != nil {
+				cacheWrite := *modelConfig.Pricing.CacheWrite
+				modelConfig.Pricing.CacheWrite = &cacheWrite
+			}
+			result[provider][model] = modelConfig
+		}
+	}
+	return result
 }
 
 type Client struct {
@@ -66,6 +117,64 @@ func resolveProvider(model string, cfg Config) (string, string) {
 		return model, "anthropic"
 	}
 	return model, "openai"
+}
+
+func (c Client) ModelConfig(model string) (ModelConfig, bool) {
+	model, provider := resolveProvider(model, c.cfg)
+	modelConfig, ok := c.cfg.Models[provider][model]
+	if !ok {
+		return ModelConfig{}, false
+	}
+	modelConfig.InputModalities = slices.Clone(modelConfig.InputModalities)
+	modelConfig.Thinking = slices.Clone(modelConfig.Thinking)
+	if modelConfig.Pricing.CacheWrite != nil {
+		cacheWrite := *modelConfig.Pricing.CacheWrite
+		modelConfig.Pricing.CacheWrite = &cacheWrite
+	}
+	return modelConfig, true
+}
+
+func (c Client) ContextWindow(model string) int {
+	modelConfig, ok := c.ModelConfig(model)
+	if !ok {
+		return 0
+	}
+	return modelConfig.ContextWindow
+}
+
+func endpointBaseURL(endpoint ProviderEndpoint, dialect types.Dialect) string {
+	if dialect == types.DialectAnthropicMessages {
+		return endpoint.AnthropicBaseURL
+	}
+	return endpoint.OpenAIBaseURL
+}
+
+func defaultBaseURL(endpoints []ProviderEndpoint, dialect types.Dialect, region string) string {
+	if region != "" {
+		for _, endpoint := range endpoints {
+			if endpoint.Region == region {
+				return endpointBaseURL(endpoint, dialect)
+			}
+		}
+	}
+	for _, endpoint := range endpoints {
+		if baseURL := endpointBaseURL(endpoint, dialect); baseURL != "" {
+			return baseURL
+		}
+	}
+	return ""
+}
+
+func isUnsetEnvReference(env map[string]string, value string) bool {
+	if len(value) < 4 || !strings.HasPrefix(value, "${") || !strings.HasSuffix(value, "}") {
+		return false
+	}
+	name := value[2 : len(value)-1]
+	if name == "" || strings.ContainsAny(name, " \t\n{}") {
+		return false
+	}
+	_, ok := env[name]
+	return !ok
 }
 
 func (c Client) Complete(ctx context.Context, req types.CompletionRequest, opts ...types.CompletionOptions) (ret *types.CompletionResponse, err error) {
@@ -154,9 +263,11 @@ func (c Client) Complete(ctx context.Context, req types.CompletionRequest, opts 
 
 func (c Client) dynamicConfig(ctx context.Context) Config {
 	cfg := Config{
-		DefaultModel:     c.defaultModel,
-		DefaultMiniModel: c.defaultMiniModel,
-		LLMProviders:     map[string]LLMProviderConfig{},
+		DefaultModel:      c.defaultModel,
+		DefaultMiniModel:  c.defaultMiniModel,
+		LLMProviders:      map[string]LLMProviderConfig{},
+		ProviderEndpoints: cloneProviderEndpoints(c.cfg.ProviderEndpoints),
+		Models:            cloneModels(c.cfg.Models),
 	}
 
 	// Start with built-in/static provider refs (env var names)
@@ -165,6 +276,7 @@ func (c Client) dynamicConfig(ctx context.Context) Config {
 			Dialect: p.Dialect,
 			APIKey:  p.APIKey,
 			BaseURL: p.BaseURL,
+			Region:  p.Region,
 			Headers: maps.Clone(p.Headers),
 		}
 	}
@@ -179,10 +291,12 @@ func (c Client) dynamicConfig(ctx context.Context) Config {
 	// Overlay providers defined in the YAML config for this session
 	typesConfig := types.ConfigFromContext(ctx)
 	for name, p := range typesConfig.LLMProviders {
+		builtIn := cfg.LLMProviders[name]
 		cfg.LLMProviders[name] = LLMProviderConfig{
 			Dialect: p.Dialect,
 			APIKey:  p.APIKey,
 			BaseURL: p.BaseURL,
+			Region:  builtIn.Region,
 			Headers: maps.Clone(p.Headers),
 		}
 	}
@@ -197,10 +311,26 @@ func (c Client) dynamicConfig(ctx context.Context) Config {
 
 	// Resolve ${VAR} references in provider config using the session env
 	for name, p := range cfg.LLMProviders {
+		region := p.Region
+		if isUnsetEnvReference(env, region) {
+			region = ""
+		} else {
+			region = envvar.ReplaceString(env, region)
+		}
+		baseURL := p.BaseURL
+		if len(cfg.ProviderEndpoints[name]) == 0 || !isUnsetEnvReference(env, baseURL) {
+			baseURL = envvar.ReplaceString(env, baseURL)
+		} else {
+			baseURL = ""
+		}
+		if baseURL == "" {
+			baseURL = defaultBaseURL(cfg.ProviderEndpoints[name], p.Dialect, region)
+		}
 		cfg.LLMProviders[name] = LLMProviderConfig{
 			Dialect: p.Dialect,
 			APIKey:  envvar.ReplaceString(env, p.APIKey),
-			BaseURL: envvar.ReplaceString(env, p.BaseURL),
+			BaseURL: baseURL,
+			Region:  region,
 			Headers: envvar.ReplaceMap(env, p.Headers),
 		}
 	}

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -2,11 +2,112 @@ package llm
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/obot-platform/nanobot/pkg/mcp"
 	"github.com/obot-platform/nanobot/pkg/types"
 )
+
+func TestDynamicConfigUsesRegisteredProviderEndpoint(t *testing.T) {
+	session := mcp.NewEmptySession(context.Background())
+	session.SetEnv(map[string]string{"MINIMAX_API_KEY": "test-key"})
+	client := NewClient(Config{
+		LLMProviders: map[string]LLMProviderConfig{
+			"minimax": {
+				Dialect: types.DialectOpenAIChatCompletions,
+				APIKey:  "${MINIMAX_API_KEY}",
+				BaseURL: "${MINIMAX_BASE_URL}",
+				Region:  "${MINIMAX_REGION}",
+			},
+		},
+		ProviderEndpoints: map[string][]ProviderEndpoint{
+			"minimax": {
+				{Region: "global_en", OpenAIBaseURL: "https://api.minimax.io/v1"},
+				{Region: "cn_zh", OpenAIBaseURL: "https://api.minimaxi.com/v1"},
+			},
+		},
+	})
+
+	dynamic := client.dynamicConfig(session.Context())
+	if got := dynamic.LLMProviders["minimax"].BaseURL; got != "https://api.minimax.io/v1" {
+		t.Fatalf("expected registered MiniMax endpoint, got %q", got)
+	}
+}
+
+func TestDynamicConfigUsesRegisteredRegionalProviderEndpoint(t *testing.T) {
+	session := mcp.NewEmptySession(context.Background())
+	session.SetEnv(map[string]string{
+		"MINIMAX_API_KEY": "test-key",
+		"MINIMAX_REGION":  "cn_zh",
+	})
+	client := NewClient(Config{
+		LLMProviders: map[string]LLMProviderConfig{
+			"minimax": {
+				Dialect: types.DialectOpenAIChatCompletions,
+				APIKey:  "${MINIMAX_API_KEY}",
+				BaseURL: "${MINIMAX_BASE_URL}",
+				Region:  "${MINIMAX_REGION}",
+			},
+		},
+		ProviderEndpoints: map[string][]ProviderEndpoint{
+			"minimax": {
+				{Region: "global_en", OpenAIBaseURL: "https://api.minimax.io/v1"},
+				{Region: "cn_zh", OpenAIBaseURL: "https://api.minimaxi.com/v1"},
+			},
+		},
+	})
+
+	dynamic := client.dynamicConfig(session.Context())
+	provider := dynamic.LLMProviders["minimax"]
+	if provider.Region != "cn_zh" {
+		t.Fatalf("expected MiniMax region cn_zh, got %q", provider.Region)
+	}
+	if provider.BaseURL != "https://api.minimaxi.com/v1" {
+		t.Fatalf("expected MiniMax China endpoint, got %q", provider.BaseURL)
+	}
+}
+
+func TestModelConfig(t *testing.T) {
+	cacheWrite := 0.375
+	client := NewClient(Config{
+		Models: map[string]map[string]ModelConfig{
+			"minimax": {
+				"MiniMax-M2.7": {
+					ContextWindow: 204_800,
+					Pricing: ModelPricing{
+						Input:      0.3,
+						Output:     1.2,
+						CacheRead:  0.06,
+						CacheWrite: &cacheWrite,
+					},
+					InputModalities: []string{"text"},
+					Thinking:        []string{"always_on"},
+				},
+			},
+		},
+	})
+
+	model, ok := client.ModelConfig("minimax/MiniMax-M2.7")
+	if !ok {
+		t.Fatal("expected MiniMax model config")
+	}
+	if model.ContextWindow != 204_800 {
+		t.Fatalf("expected context window 204800, got %d", model.ContextWindow)
+	}
+	if model.Pricing.Input != 0.3 || model.Pricing.Output != 1.2 || model.Pricing.CacheRead != 0.06 {
+		t.Fatalf("unexpected MiniMax model pricing: %+v", model.Pricing)
+	}
+	if model.Pricing.CacheWrite == nil || *model.Pricing.CacheWrite != 0.375 {
+		t.Fatalf("unexpected MiniMax cache write pricing: %v", model.Pricing.CacheWrite)
+	}
+	if !slices.Equal(model.InputModalities, []string{"text"}) {
+		t.Fatalf("unexpected MiniMax input modalities: %v", model.InputModalities)
+	}
+	if !slices.Equal(model.Thinking, []string{"always_on"}) {
+		t.Fatalf("unexpected MiniMax thinking modes: %v", model.Thinking)
+	}
+}
 
 func TestResolveProvider(t *testing.T) {
 	cfg := Config{


### PR DESCRIPTION
Reason: Refresh MiniMax configuration with regional endpoints and current model metadata.

- Registers selectable global and China endpoints while preserving an explicit base URL override.
- Adds MiniMax-M3 and MiniMax-M2.7 context, pricing, thinking, and input modality profiles.
- Uses registered context windows for compaction when the agent does not provide an override.
- Prevents an unset MiniMax base URL from using the generic client default.

Checks:
- `make validate`
