### PR TITLE
feat: support video resources in chat completions

### DIFF
--- a/pkg/llm/completions/translate.go
+++ b/pkg/llm/completions/translate.go
@@ -181,6 +181,13 @@ func toRequest(req *types.CompletionRequest) (Request, error) {
 										Detail: "auto",
 									},
 								})
+							} else if mimeType, ok := types.VideoMimeTypes[item.Content.Resource.MIMEType]; ok {
+								parts = append(parts, ContentPart{
+									Type: "video_url",
+									VideoURL: &VideoURL{
+										URL: fmt.Sprintf("data:%s;base64,%s", mimeType, item.Content.Resource.Blob),
+									},
+								})
 							} else if _, ok := types.TextMimeTypes[item.Content.Resource.MIMEType]; ok {
 								text := item.Content.Resource.Text
 								if item.Content.Resource.Blob != "" {

--- a/pkg/llm/completions/translate_test.go
+++ b/pkg/llm/completions/translate_test.go
@@ -1,0 +1,62 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/obot-platform/nanobot/pkg/mcp"
+	"github.com/obot-platform/nanobot/pkg/types"
+)
+
+func TestToRequestIncludesVideoResources(t *testing.T) {
+	tests := []struct {
+		name         string
+		mimeType     string
+		expectedMIME string
+	}{
+		{name: "MP4", mimeType: "video/mp4", expectedMIME: "video/mp4"},
+		{name: "MOV", mimeType: "video/quicktime", expectedMIME: "video/mov"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := toRequest(&types.CompletionRequest{
+				Model: "video-capable-model",
+				Input: []types.Message{
+					{
+						Role: "user",
+						Items: []types.CompletionItem{
+							{
+								Content: &mcp.Content{
+									Type: "resource",
+									Resource: &mcp.EmbeddedResource{
+										URI:      "file:///clip",
+										MIMEType: tt.mimeType,
+										Blob:     "dmlkZW8=",
+										Annotations: &mcp.ResourceAnnotations{
+											Audience: []string{"assistant"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("toRequest failed: %v", err)
+			}
+
+			parts := req.Messages[0].Content.ContentParts
+			if len(parts) != 1 {
+				t.Fatalf("expected one content part, got %d", len(parts))
+			}
+			if parts[0].Type != "video_url" || parts[0].VideoURL == nil {
+				t.Fatalf("expected video_url content part, got %+v", parts[0])
+			}
+			expectedURL := "data:" + tt.expectedMIME + ";base64,dmlkZW8="
+			if parts[0].VideoURL.URL != expectedURL {
+				t.Fatalf("expected video URL %q, got %q", expectedURL, parts[0].VideoURL.URL)
+			}
+		})
+	}
+}

--- a/pkg/llm/completions/types.go
+++ b/pkg/llm/completions/types.go
@@ -67,11 +67,16 @@ type ContentPart struct {
 	Type     string    `json:"type"`
 	Text     string    `json:"text,omitempty"`
 	ImageURL *ImageURL `json:"image_url,omitempty"`
+	VideoURL *VideoURL `json:"video_url,omitempty"`
 }
 
 type ImageURL struct {
 	URL    string `json:"url"`
 	Detail string `json:"detail,omitempty"`
+}
+
+type VideoURL struct {
+	URL string `json:"url"`
 }
 
 type Tool struct {

--- a/pkg/types/mimetypes.go
+++ b/pkg/types/mimetypes.go
@@ -27,6 +27,15 @@ var (
 		"image/jpeg": {},
 		"image/webp": {},
 	}
+	// VideoMimeTypes maps detected MIME types to MIME types accepted in base64 data URLs.
+	VideoMimeTypes = map[string]string{
+		"video/mp4":        "video/mp4",
+		"video/avi":        "video/avi",
+		"video/x-msvideo":  "video/x-msvideo",
+		"video/mov":        "video/mov",
+		"video/quicktime":  "video/mov",
+		"video/x-matroska": "video/x-matroska",
+	}
 	TextMimeTypes = map[string]struct{}{
 		"text/plain":             {},
 		"text/markdown":          {},


### PR DESCRIPTION
Reason: Allow video resources to reach video-capable chat completion models.

- Adds supported video MIME mappings, including MOV data URL normalization.
- Translates assistant-visible video resources into `video_url` content parts.
- Covers MP4 and MOV resource translation.

Checks:
- `go test ./pkg/llm/completions ./pkg/types`
- `make validate`
