### PR TITLE
feat: introduce new v1 hook contract

### DIFF
--- a/pkg/filter/contract.go
+++ b/pkg/filter/contract.go
@@ -1,0 +1,218 @@
+// Package filter defines the versioned wire contract used by Obot Filters.
+//
+// The package deliberately contains only contract types and validation helpers
+// so other services can consume it without importing nanobot application code.
+package filter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const APIVersionV1 = "obot.obot.ai/filter/v1"
+
+type ContractVersion string
+
+const (
+	ContractVersionLegacyMCP ContractVersion = ""
+	ContractVersionV1        ContractVersion = APIVersionV1
+)
+
+type Source string
+
+const (
+	SourceMCP        Source = "mcp"
+	SourceLocalAgent Source = "local_agent"
+)
+
+type EventType string
+
+const (
+	EventTypeMCPMessage EventType = "mcp_message"
+	EventTypeUserPrompt EventType = "user_prompt"
+	EventTypeToolCall   EventType = "tool_call"
+)
+
+type Phase string
+
+const (
+	PhaseRequest  Phase = "request"
+	PhaseResponse Phase = "response"
+	PhaseFailure  Phase = "failure"
+)
+
+type Surface string
+
+const (
+	SurfaceUserPrompt    Surface = "user_prompt"
+	SurfaceToolArguments Surface = "tool_arguments"
+	SurfaceToolResponse  Surface = "tool_response"
+)
+
+type Decision string
+
+const (
+	DecisionAccept Decision = "accept"
+	DecisionReject Decision = "reject"
+	DecisionMutate Decision = "mutate"
+)
+
+// Request is the common v1 Filter request envelope. Payload is the complete
+// value being evaluated; it is never a partial update.
+type Request struct {
+	APIVersion   string          `json:"apiVersion"`
+	Source       Source          `json:"source"`
+	Event        Event           `json:"event"`
+	Context      Context         `json:"context"`
+	Capabilities Capabilities    `json:"capabilities"`
+	Payload      json.RawMessage `json:"payload"`
+}
+
+type Event struct {
+	Type       EventType `json:"type"`
+	Phase      Phase     `json:"phase"`
+	Surface    Surface   `json:"surface,omitempty"`
+	Method     string    `json:"method,omitempty"`
+	Identifier string    `json:"identifier,omitempty"`
+}
+
+type Context struct {
+	Trace       *TraceContext       `json:"trace,omitempty"`
+	MCP         *MCPContext         `json:"mcp,omitempty"`
+	LocalAgent  *LocalAgentContext  `json:"localAgent,omitempty"`
+	Device      *DeviceContext      `json:"device,omitempty"`
+	Environment *EnvironmentContext `json:"environment,omitempty"`
+}
+
+type TraceContext struct {
+	EventID   string `json:"eventId,omitempty"`
+	SessionID string `json:"sessionId,omitempty"`
+	TurnID    string `json:"turnId,omitempty"`
+	ToolUseID string `json:"toolUseId,omitempty"`
+}
+
+type MCPContext struct {
+	ServerName      string `json:"serverName,omitempty"`
+	ServerShortName string `json:"serverShortName,omitempty"`
+}
+
+type LocalAgentContext struct {
+	Provider     string `json:"provider"`
+	AgentVersion string `json:"agentVersion,omitempty"`
+	Model        string `json:"model,omitempty"`
+	ModelID      string `json:"modelId,omitempty"`
+	ToolName     string `json:"toolName,omitempty"`
+	ToolKind     string `json:"toolKind,omitempty"`
+}
+
+type DeviceContext struct {
+	ID           string `json:"id"`
+	DeploymentID string `json:"deploymentId"`
+}
+
+type EnvironmentContext struct {
+	OperatingSystem  string `json:"operatingSystem,omitempty"`
+	Architecture     string `json:"architecture,omitempty"`
+	WorkingDirectory string `json:"workingDirectory,omitempty"`
+}
+
+type Capabilities struct {
+	CanReject bool `json:"canReject"`
+	CanMutate bool `json:"canMutate"`
+}
+
+// Response is the common v1 Filter response. Payload must be present only for
+// mutate and is the complete replacement value.
+type Response struct {
+	Decision Decision        `json:"decision"`
+	Reason   string          `json:"reason,omitempty"`
+	Payload  json.RawMessage `json:"payload,omitempty"`
+}
+
+func (r Request) Validate() error {
+	if r.APIVersion != APIVersionV1 {
+		return fmt.Errorf("unsupported filter API version %q", r.APIVersion)
+	}
+	if len(r.Payload) == 0 || !json.Valid(r.Payload) {
+		return errors.New("filter payload must be valid JSON")
+	}
+
+	switch r.Source {
+	case SourceMCP:
+		if r.Event.Type != EventTypeMCPMessage {
+			return errors.New("MCP source requires an mcp_message event")
+		}
+		if r.Event.Phase != PhaseRequest && r.Event.Phase != PhaseResponse && r.Event.Phase != PhaseFailure {
+			return errors.New("MCP event requires a request, response, or failure phase")
+		}
+		if r.Event.Surface != "" {
+			return errors.New("MCP events must not declare a local-agent surface")
+		}
+	case SourceLocalAgent:
+		if err := r.Event.validateLocalAgent(); err != nil {
+			return err
+		}
+		if r.Context.LocalAgent == nil || r.Context.LocalAgent.Provider == "" {
+			return errors.New("local-agent events require an agent provider")
+		}
+		if r.Context.Device == nil || r.Context.Device.ID == "" || r.Context.Device.DeploymentID == "" {
+			return errors.New("local-agent events require authenticated device and deployment identity")
+		}
+		if r.Event.Surface == SurfaceUserPrompt && r.Capabilities.CanMutate {
+			return errors.New("user prompts cannot advertise mutation capability")
+		}
+	default:
+		return fmt.Errorf("unknown filter source %q", r.Source)
+	}
+
+	return nil
+}
+
+func (e Event) validateLocalAgent() error {
+	switch e.Surface {
+	case SurfaceUserPrompt:
+		if e.Type != EventTypeUserPrompt || e.Phase != PhaseRequest {
+			return errors.New("user_prompt surface requires a user_prompt request event")
+		}
+	case SurfaceToolArguments:
+		if e.Type != EventTypeToolCall || e.Phase != PhaseRequest {
+			return errors.New("tool_arguments surface requires a tool_call request event")
+		}
+	case SurfaceToolResponse:
+		if e.Type != EventTypeToolCall || (e.Phase != PhaseResponse && e.Phase != PhaseFailure) {
+			return errors.New("tool_response surface requires a tool_call response or failure event")
+		}
+	default:
+		return fmt.Errorf("unknown local-agent surface %q", e.Surface)
+	}
+	return nil
+}
+
+func (r Response) Validate(capabilities Capabilities) error {
+	hasPayload := len(bytes.TrimSpace(r.Payload)) != 0
+	switch r.Decision {
+	case DecisionAccept:
+		if hasPayload {
+			return fmt.Errorf("%s response must not contain a payload", r.Decision)
+		}
+	case DecisionReject:
+		if !capabilities.CanReject {
+			return errors.New("rejection not allowed by filter capabilities")
+		}
+		if hasPayload {
+			return fmt.Errorf("%s response must not contain a payload", r.Decision)
+		}
+	case DecisionMutate:
+		if !capabilities.CanMutate {
+			return errors.New("mutation not allowed by filter capabilities")
+		}
+		if !hasPayload || !json.Valid(r.Payload) {
+			return errors.New("mutate response requires a valid JSON payload")
+		}
+	default:
+		return fmt.Errorf("unknown filter decision %q", r.Decision)
+	}
+	return nil
+}

--- a/pkg/filter/contract.go
+++ b/pkg/filter/contract.go
@@ -59,6 +59,12 @@ const (
 	DecisionMutate Decision = "mutate"
 )
 
+// ToolRequest is the MCP tool input for a v1 Filter. The wrapper maps directly
+// to an ordinary MCP tool parameter named "request" in SDKs such as FastMCP.
+type ToolRequest struct {
+	Request Request `json:"request"`
+}
+
 // Request is the common v1 Filter request envelope. Payload is the complete
 // value being evaluated; it is never a partial update.
 type Request struct {

--- a/pkg/filter/contract_test.go
+++ b/pkg/filter/contract_test.go
@@ -94,7 +94,14 @@ func TestRequestValidationRejectsBadDiscriminators(t *testing.T) {
 			Phase:   PhaseRequest,
 			Surface: SurfaceUserPrompt,
 		},
+		Context: Context{
+			LocalAgent: &LocalAgentContext{Provider: "test"},
+			Device:     &DeviceContext{ID: "device", DeploymentID: "deployment"},
+		},
 		Payload: json.RawMessage(`"hello"`),
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("valid baseline: %v", err)
 	}
 	tests := map[string]func(*Request){
 		"version": func(r *Request) { r.APIVersion = "v2" },

--- a/pkg/filter/contract_test.go
+++ b/pkg/filter/contract_test.go
@@ -34,6 +34,30 @@ func TestV1RequestFixtures(t *testing.T) {
 	}
 }
 
+func TestV1ToolRequestWrapsEnvelope(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata/v1", "mcp-request.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request Request
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapped, err := json.Marshal(ToolRequest{Request: request})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal(wrapped, &value); err != nil {
+		t.Fatal(err)
+	}
+	if len(value) != 1 {
+		t.Fatalf("tool input fields = %v, want only request", value)
+	}
+	assertJSONEquivalent(t, data, json.RawMessage(value["request"]))
+}
+
 func TestV1ResponseFixtures(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/filter/contract_test.go
+++ b/pkg/filter/contract_test.go
@@ -1,0 +1,133 @@
+package filter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestV1RequestFixtures(t *testing.T) {
+	paths, err := filepath.Glob("testdata/v1/*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range paths {
+		if strings.Contains(filepath.Base(path), "response-") {
+			continue
+		}
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var request Request
+			if err := json.Unmarshal(data, &request); err != nil {
+				t.Fatal(err)
+			}
+			if err := request.Validate(); err != nil {
+				t.Fatal(err)
+			}
+			assertJSONEquivalent(t, data, request)
+		})
+	}
+}
+
+func TestV1ResponseFixtures(t *testing.T) {
+	tests := []struct {
+		name      string
+		canMutate bool
+	}{
+		{name: "response-accept.json"},
+		{name: "response-reject.json"},
+		{name: "response-mutate.json", canMutate: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata/v1", tt.name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var response Response
+			if err := json.Unmarshal(data, &response); err != nil {
+				t.Fatal(err)
+			}
+			if err := response.Validate(Capabilities{CanReject: true, CanMutate: tt.canMutate}); err != nil {
+				t.Fatal(err)
+			}
+			assertJSONEquivalent(t, data, response)
+		})
+	}
+}
+
+func TestRequestValidationRejectsBadDiscriminators(t *testing.T) {
+	base := Request{
+		APIVersion: APIVersionV1,
+		Source:     SourceLocalAgent,
+		Event: Event{
+			Type:    EventTypeUserPrompt,
+			Phase:   PhaseRequest,
+			Surface: SurfaceUserPrompt,
+		},
+		Payload: json.RawMessage(`"hello"`),
+	}
+	tests := map[string]func(*Request){
+		"version": func(r *Request) { r.APIVersion = "v2" },
+		"source":  func(r *Request) { r.Source = "unknown" },
+		"type":    func(r *Request) { r.Event.Type = EventTypeToolCall },
+		"phase":   func(r *Request) { r.Event.Phase = PhaseResponse },
+		"surface": func(r *Request) { r.Event.Surface = "unknown" },
+		"payload": func(r *Request) { r.Payload = nil },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := base
+			mutate(&request)
+			if err := request.Validate(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestResponseValidation(t *testing.T) {
+	tests := []Response{
+		{},
+		{Decision: "unknown"},
+		{Decision: DecisionAccept, Payload: json.RawMessage(`{}`)},
+		{Decision: DecisionReject, Payload: json.RawMessage(`null`)},
+		{Decision: DecisionMutate},
+		{Decision: DecisionMutate, Payload: json.RawMessage(`not-json`)},
+	}
+	for _, response := range tests {
+		if err := response.Validate(Capabilities{CanReject: true, CanMutate: true}); err == nil {
+			t.Fatalf("expected validation error for %#v", response)
+		}
+	}
+
+	response := Response{Decision: DecisionMutate, Payload: json.RawMessage(`{}`)}
+	if err := response.Validate(Capabilities{CanReject: true}); err == nil {
+		t.Fatal("expected forbidden mutation to fail validation")
+	}
+}
+
+func assertJSONEquivalent(t *testing.T, expected []byte, actual any) {
+	t.Helper()
+	actualData, err := json.Marshal(actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expectedValue, actualValue any
+	if err := json.Unmarshal(expected, &expectedValue); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(actualData, &actualValue); err != nil {
+		t.Fatal(err)
+	}
+	expectedData, _ := json.Marshal(expectedValue)
+	actualData, _ = json.Marshal(actualValue)
+	if string(expectedData) != string(actualData) {
+		t.Fatalf("JSON mismatch\nexpected: %s\nactual:   %s", expectedData, actualData)
+	}
+}

--- a/pkg/filter/testdata/v1/local-agent-tool-arguments.json
+++ b/pkg/filter/testdata/v1/local-agent-tool-arguments.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "local_agent",
+  "event": {
+    "type": "tool_call",
+    "phase": "request",
+    "surface": "tool_arguments",
+    "method": "shell",
+    "identifier": "run_terminal_command"
+  },
+  "context": {
+    "trace": {
+      "eventId": "event-tool-1",
+      "sessionId": "session-123",
+      "turnId": "turn-7",
+      "toolUseId": "tool-9"
+    },
+    "localAgent": {
+      "provider": "vscode",
+      "agentVersion": "1.105.0",
+      "model": "gpt-5",
+      "toolName": "run_terminal_command",
+      "toolKind": "shell"
+    },
+    "device": {
+      "id": "device-123",
+      "deploymentId": "deployment-456"
+    },
+    "environment": {
+      "operatingSystem": "windows",
+      "architecture": "amd64",
+      "workingDirectory": "C:\\workspace\\project"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": true
+  },
+  "payload": {
+    "command": "go test ./...",
+    "timeoutMs": 30000
+  }
+}

--- a/pkg/filter/testdata/v1/local-agent-tool-failure.json
+++ b/pkg/filter/testdata/v1/local-agent-tool-failure.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "local_agent",
+  "event": {
+    "type": "tool_call",
+    "phase": "failure",
+    "surface": "tool_response",
+    "method": "shell",
+    "identifier": "run_terminal_command"
+  },
+  "context": {
+    "trace": {
+      "eventId": "event-tool-3",
+      "sessionId": "session-123",
+      "turnId": "turn-7",
+      "toolUseId": "tool-10"
+    },
+    "localAgent": {
+      "provider": "codex",
+      "agentVersion": "0.20.0",
+      "model": "gpt-5",
+      "toolName": "run_terminal_command",
+      "toolKind": "shell"
+    },
+    "device": {
+      "id": "device-123",
+      "deploymentId": "deployment-456"
+    },
+    "environment": {
+      "operatingSystem": "darwin",
+      "architecture": "arm64",
+      "workingDirectory": "/workspace/project"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": false
+  },
+  "payload": {
+    "exitCode": 1,
+    "error": "command failed"
+  }
+}

--- a/pkg/filter/testdata/v1/local-agent-tool-response.json
+++ b/pkg/filter/testdata/v1/local-agent-tool-response.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "local_agent",
+  "event": {
+    "type": "tool_call",
+    "phase": "response",
+    "surface": "tool_response",
+    "method": "shell",
+    "identifier": "run_terminal_command"
+  },
+  "context": {
+    "trace": {
+      "eventId": "event-tool-2",
+      "sessionId": "session-123",
+      "turnId": "turn-7",
+      "toolUseId": "tool-9"
+    },
+    "localAgent": {
+      "provider": "vscode",
+      "agentVersion": "1.105.0",
+      "model": "gpt-5",
+      "toolName": "run_terminal_command",
+      "toolKind": "shell"
+    },
+    "device": {
+      "id": "device-123",
+      "deploymentId": "deployment-456"
+    },
+    "environment": {
+      "operatingSystem": "windows",
+      "architecture": "amd64",
+      "workingDirectory": "C:\\workspace\\project"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": false
+  },
+  "payload": {
+    "exitCode": 0,
+    "stdout": "ok\n",
+    "stderr": ""
+  }
+}

--- a/pkg/filter/testdata/v1/local-agent-user-prompt.json
+++ b/pkg/filter/testdata/v1/local-agent-user-prompt.json
@@ -1,0 +1,37 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "local_agent",
+  "event": {
+    "type": "user_prompt",
+    "phase": "request",
+    "surface": "user_prompt",
+    "identifier": "current_prompt"
+  },
+  "context": {
+    "trace": {
+      "eventId": "event-prompt-1",
+      "sessionId": "session-123",
+      "turnId": "turn-7"
+    },
+    "localAgent": {
+      "provider": "claude_code",
+      "agentVersion": "1.2.3",
+      "model": "Claude Sonnet",
+      "modelId": "claude-sonnet"
+    },
+    "device": {
+      "id": "device-123",
+      "deploymentId": "deployment-456"
+    },
+    "environment": {
+      "operatingSystem": "darwin",
+      "architecture": "arm64",
+      "workingDirectory": "/workspace/project"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": false
+  },
+  "payload": "Summarize the current change."
+}

--- a/pkg/filter/testdata/v1/mcp-failure.json
+++ b/pkg/filter/testdata/v1/mcp-failure.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "mcp",
+  "event": {
+    "type": "mcp_message",
+    "phase": "failure",
+    "method": "tools/call",
+    "identifier": "search"
+  },
+  "context": {
+    "trace": {
+      "sessionId": "session-123"
+    },
+    "mcp": {
+      "serverName": "search-server",
+      "serverShortName": "search"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": true
+  },
+  "payload": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search",
+      "arguments": {
+        "query": "release notes"
+      }
+    },
+    "error": {
+      "code": -32603,
+      "message": "upstream tool failed"
+    }
+  }
+}

--- a/pkg/filter/testdata/v1/mcp-request.json
+++ b/pkg/filter/testdata/v1/mcp-request.json
@@ -1,0 +1,34 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "mcp",
+  "event": {
+    "type": "mcp_message",
+    "phase": "request",
+    "method": "tools/call",
+    "identifier": "search"
+  },
+  "context": {
+    "trace": {
+      "sessionId": "session-123"
+    },
+    "mcp": {
+      "serverName": "search-server",
+      "serverShortName": "search"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": true
+  },
+  "payload": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search",
+      "arguments": {
+        "query": "release notes"
+      }
+    }
+  }
+}

--- a/pkg/filter/testdata/v1/mcp-response.json
+++ b/pkg/filter/testdata/v1/mcp-response.json
@@ -1,0 +1,42 @@
+{
+  "apiVersion": "obot.obot.ai/filter/v1",
+  "source": "mcp",
+  "event": {
+    "type": "mcp_message",
+    "phase": "response",
+    "method": "tools/call",
+    "identifier": "search"
+  },
+  "context": {
+    "trace": {
+      "sessionId": "session-123"
+    },
+    "mcp": {
+      "serverName": "search-server",
+      "serverShortName": "search"
+    }
+  },
+  "capabilities": {
+    "canReject": true,
+    "canMutate": true
+  },
+  "payload": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search",
+      "arguments": {
+        "query": "release notes"
+      }
+    },
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "result"
+        }
+      ]
+    }
+  }
+}

--- a/pkg/filter/testdata/v1/response-accept.json
+++ b/pkg/filter/testdata/v1/response-accept.json
@@ -1,0 +1,4 @@
+{
+  "decision": "accept",
+  "reason": "content is allowed"
+}

--- a/pkg/filter/testdata/v1/response-mutate.json
+++ b/pkg/filter/testdata/v1/response-mutate.json
@@ -1,0 +1,7 @@
+{
+  "decision": "mutate",
+  "reason": "sensitive content was redacted",
+  "payload": {
+    "redacted": true
+  }
+}

--- a/pkg/filter/testdata/v1/response-reject.json
+++ b/pkg/filter/testdata/v1/response-reject.json
@@ -1,0 +1,4 @@
+{
+  "decision": "reject",
+  "reason": "content violates policy"
+}

--- a/pkg/mcp/filter.go
+++ b/pkg/mcp/filter.go
@@ -41,7 +41,7 @@ func newMCPFilterRequest(message *Message, direction, method, identifier string,
 	return request, nil
 }
 
-func normalizeV1FilterResponse(response filtercontract.Response, current *Message, identifier string, capabilities filtercontract.Capabilities) (SessionMessageHook, error) {
+func normalizeV1FilterResponse(response filtercontract.Response, current *Message, direction, identifier string, capabilities filtercontract.Capabilities) (SessionMessageHook, error) {
 	validationCapabilities := capabilities
 	if response.Decision == filtercontract.DecisionMutate {
 		// Validate the replacement payload independently from authorization so a
@@ -69,6 +69,9 @@ func normalizeV1FilterResponse(response filtercontract.Response, current *Messag
 		if message.JSONRPC != current.JSONRPC || message.Method != current.Method || !reflect.DeepEqual(message.ID, current.ID) || getMessageName(&message) != identifier {
 			return SessionMessageHook{}, errors.New("invalid v1 Filter response: mutation changed immutable MCP message identity")
 		}
+		if err := validateMCPMutationShape(&message, direction); err != nil {
+			return SessionMessageHook{}, fmt.Errorf("invalid v1 Filter response: %w", err)
+		}
 		if !capabilities.CanMutate {
 			return SessionMessageHook{
 				Accept:             false,
@@ -85,8 +88,27 @@ func normalizeV1FilterResponse(response filtercontract.Response, current *Messag
 			NormalizedDecision: filtercontract.DecisionMutate,
 		}, nil
 	default:
-		panic("validated Filter response has an unknown decision")
+		return SessionMessageHook{}, fmt.Errorf("invalid v1 Filter response: unhandled decision %q", response.Decision)
 	}
+}
+
+func validateMCPMutationShape(message *Message, direction string) error {
+	hasResult := len(bytes.TrimSpace(message.Result)) != 0
+	hasError := message.Error != nil
+
+	switch direction {
+	case "request":
+		if hasResult || hasError {
+			return errors.New("request mutation must not contain result or error")
+		}
+	case "response":
+		if hasResult == hasError {
+			return errors.New("response mutation must contain exactly one of result or error")
+		}
+	default:
+		return fmt.Errorf("unknown MCP message direction %q", direction)
+	}
+	return nil
 }
 
 func normalizeLegacyFilterResponse(response SessionMessageHook, current *Message, mutateDisallowed bool) (SessionMessageHook, error) {

--- a/pkg/mcp/filter.go
+++ b/pkg/mcp/filter.go
@@ -1,0 +1,124 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	filtercontract "github.com/obot-platform/nanobot/pkg/filter"
+)
+
+const mutationDisallowedReason = "mutation not allowed by hook configuration, implicit rejection"
+
+func newMCPFilterRequest(message *Message, direction, method, identifier string, context filtercontract.Context, capabilities filtercontract.Capabilities) (filtercontract.Request, error) {
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return filtercontract.Request{}, fmt.Errorf("failed to marshal MCP Filter payload: %w", err)
+	}
+
+	phase := filtercontract.Phase(direction)
+	if direction == "response" && message.Error != nil {
+		phase = filtercontract.PhaseFailure
+	}
+	request := filtercontract.Request{
+		APIVersion: filtercontract.APIVersionV1,
+		Source:     filtercontract.SourceMCP,
+		Event: filtercontract.Event{
+			Type:       filtercontract.EventTypeMCPMessage,
+			Phase:      phase,
+			Method:     method,
+			Identifier: identifier,
+		},
+		Context:      context,
+		Capabilities: capabilities,
+		Payload:      payload,
+	}
+	if err := request.Validate(); err != nil {
+		return filtercontract.Request{}, fmt.Errorf("invalid MCP Filter request: %w", err)
+	}
+	return request, nil
+}
+
+func normalizeV1FilterResponse(response filtercontract.Response, current *Message, identifier string, capabilities filtercontract.Capabilities) (SessionMessageHook, error) {
+	validationCapabilities := capabilities
+	if response.Decision == filtercontract.DecisionMutate {
+		// Validate the replacement payload independently from authorization so a
+		// malformed mutation remains an invalid response, not a policy rejection.
+		validationCapabilities.CanMutate = true
+	}
+	if err := response.Validate(validationCapabilities); err != nil {
+		return SessionMessageHook{}, fmt.Errorf("invalid v1 Filter response: %w", err)
+	}
+
+	switch response.Decision {
+	case filtercontract.DecisionAccept:
+		return SessionMessageHook{Accept: true, Message: current, Reason: response.Reason, NormalizedDecision: filtercontract.DecisionAccept}, nil
+	case filtercontract.DecisionReject:
+		return SessionMessageHook{Message: current, Reason: response.Reason, NormalizedDecision: filtercontract.DecisionReject}, nil
+	case filtercontract.DecisionMutate:
+		trimmed := bytes.TrimSpace(response.Payload)
+		if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) || trimmed[0] != '{' {
+			return SessionMessageHook{}, errors.New("invalid v1 Filter response: mutation payload must be an MCP message object")
+		}
+		var message Message
+		if err := json.Unmarshal(response.Payload, &message); err != nil {
+			return SessionMessageHook{}, fmt.Errorf("invalid v1 Filter response: mutation payload must be an MCP message: %w", err)
+		}
+		if message.JSONRPC != current.JSONRPC || message.Method != current.Method || !reflect.DeepEqual(message.ID, current.ID) || getMessageName(&message) != identifier {
+			return SessionMessageHook{}, errors.New("invalid v1 Filter response: mutation changed immutable MCP message identity")
+		}
+		if !capabilities.CanMutate {
+			return SessionMessageHook{
+				Accept:             false,
+				Message:            current,
+				Reason:             appendReason(response.Reason, mutationDisallowedReason),
+				NormalizedDecision: filtercontract.DecisionReject,
+			}, nil
+		}
+		return SessionMessageHook{
+			Accept:             true,
+			Mutated:            true,
+			Message:            &message,
+			Reason:             response.Reason,
+			NormalizedDecision: filtercontract.DecisionMutate,
+		}, nil
+	default:
+		panic("validated Filter response has an unknown decision")
+	}
+}
+
+func normalizeLegacyFilterResponse(response SessionMessageHook, current *Message, mutateDisallowed bool) (SessionMessageHook, error) {
+	if !response.Accept {
+		response.Mutated = false
+		response.Message = current
+		response.NormalizedDecision = filtercontract.DecisionReject
+		return response, nil
+	}
+	if !response.Mutated {
+		response.Message = current
+		response.NormalizedDecision = filtercontract.DecisionAccept
+		return response, nil
+	}
+	if response.Message == nil {
+		return SessionMessageHook{}, errors.New("invalid legacy Filter response: mutation requires a message")
+	}
+	if mutateDisallowed {
+		return SessionMessageHook{
+			Accept:             false,
+			Message:            current,
+			Reason:             appendReason(response.Reason, mutationDisallowedReason),
+			NormalizedDecision: filtercontract.DecisionReject,
+		}, nil
+	}
+	response.NormalizedDecision = filtercontract.DecisionMutate
+	return response, nil
+}
+
+func appendReason(reason, addition string) string {
+	if reason == "" {
+		return addition
+	}
+	return reason + "; " + addition
+}

--- a/pkg/mcp/hooks.go
+++ b/pkg/mcp/hooks.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+
+	filtercontract "github.com/obot-platform/nanobot/pkg/filter"
 )
 
 type HookRunner interface {
@@ -98,6 +100,7 @@ type HookMapping struct {
 type HookTarget struct {
 	Target           string
 	MutateDisallowed bool
+	ContractVersion  filtercontract.ContractVersion
 }
 
 func (h *HookTarget) UnmarshalJSON(data []byte) error {
@@ -105,13 +108,33 @@ func (h *HookTarget) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &target); err != nil {
 		return err
 	}
+	*h = HookTarget{}
 
-	h.Target, h.MutateDisallowed = strings.CutPrefix(target, "!mutate:")
+	for {
+		var found bool
+		if target, found = strings.CutPrefix(target, "!mutate:"); found {
+			h.MutateDisallowed = true
+			continue
+		}
+		if target, found = strings.CutPrefix(target, "!filter-v1:"); found {
+			h.ContractVersion = filtercontract.ContractVersionV1
+			continue
+		}
+		break
+	}
+	h.Target = target
 	return nil
 }
 
-func (h *HookTarget) MarshalJSON() ([]byte, error) {
+func (h HookTarget) MarshalJSON() ([]byte, error) {
 	target := h.Target
+	switch h.ContractVersion {
+	case filtercontract.ContractVersionLegacyMCP:
+	case filtercontract.ContractVersionV1:
+		target = "!filter-v1:" + target
+	default:
+		return nil, fmt.Errorf("unsupported Filter contract version %q", h.ContractVersion)
+	}
 	if h.MutateDisallowed {
 		target = "!mutate:" + target
 	}

--- a/pkg/mcp/hooks_test.go
+++ b/pkg/mcp/hooks_test.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	filtercontract "github.com/obot-platform/nanobot/pkg/filter"
+)
+
+func TestHookTargetContractVersionSerialization(t *testing.T) {
+	tests := []struct {
+		name   string
+		target HookTarget
+		want   string
+	}{
+		{name: "legacy", target: HookTarget{Target: "filter/tool"}, want: `"filter/tool"`},
+		{name: "legacy mutation disabled", target: HookTarget{Target: "filter/tool", MutateDisallowed: true}, want: `"!mutate:filter/tool"`},
+		{name: "v1", target: HookTarget{Target: "filter/tool", ContractVersion: filtercontract.ContractVersionV1}, want: `"!filter-v1:filter/tool"`},
+		{name: "v1 mutation disabled", target: HookTarget{Target: "filter/tool", MutateDisallowed: true, ContractVersion: filtercontract.ContractVersionV1}, want: `"!mutate:!filter-v1:filter/tool"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tt.want {
+				t.Fatalf("got %s, want %s", data, tt.want)
+			}
+			var roundTrip HookTarget
+			if err := json.Unmarshal(data, &roundTrip); err != nil {
+				t.Fatal(err)
+			}
+			if roundTrip != tt.target {
+				t.Fatalf("round trip = %#v, want %#v", roundTrip, tt.target)
+			}
+		})
+	}
+}
+
+func TestLegacyHooksJSONIsUnchanged(t *testing.T) {
+	hooks := Hooks{{
+		Name:   "tools/call",
+		Params: map[string]string{"name": "search"},
+		Targets: []HookTarget{
+			{Target: "first/filter"},
+			{Target: "second/filter", MutateDisallowed: true},
+		},
+	}}
+	data, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"tools/call?name=search":["first/filter","!mutate:second/filter"]}`
+	if string(data) != want {
+		t.Fatalf("got %s, want %s", data, want)
+	}
+}

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/obot-platform/nanobot/pkg/complete"
+	filtercontract "github.com/obot-platform/nanobot/pkg/filter"
 	"github.com/obot-platform/nanobot/pkg/mcp/auditlogs"
 )
 
@@ -774,6 +775,7 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 		hooks    = s.hooks
 		name     = getMessageName(req)
 		auditLog = AuditLogFromContext(ctx)
+		server   = MCPServerConfigFromContext(ctx)
 		errs     []error
 	)
 	if len(hooks) == 0 {
@@ -791,31 +793,46 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 		"method":      req.Method,
 	}
 
+	filterContext := filtercontract.Context{}
+	if sessionID := s.ID(); sessionID != "" {
+		filterContext.Trace = &filtercontract.TraceContext{SessionID: sessionID}
+	}
+	if server.Name != "" || server.ShortName != "" {
+		filterContext.MCP = &filtercontract.MCPContext{
+			ServerName:      server.Name,
+			ServerShortName: server.ShortName,
+		}
+	}
+
 	// errs will be caught in callback, we don't need to handle the return err
-	hookResponse, _ := InvokeHooks(ctx, s.HookRunner, hooks, &SessionMessageHook{
-		Accept:  true,
-		Message: req,
-	}, req.Method, params, func(hook HookMapping, target HookTarget, hookResponse SessionMessageHook, err error) SessionMessageHook {
+	hookResponse, _ := invokeMCPFilterHooks(ctx, s.HookRunner, hooks, &SessionMessageHook{
+		Accept:             true,
+		Message:            req,
+		NormalizedDecision: filtercontract.DecisionAccept,
+	}, req.Method, params, direction, name, filterContext, func(hook HookMapping, target HookTarget, hookResponse SessionMessageHook, err error) SessionMessageHook {
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to run hook %s: %w", hook.Name, err))
+			if auditLog != nil {
+				auditLog.WebhookStatuses = append(auditLog.WebhookStatuses, auditlogs.MCPWebhookStatus{
+					Type:    direction,
+					Method:  req.Method,
+					Name:    hook.Name,
+					Tool:    target.Target,
+					Status:  "failed",
+					Message: err.Error(),
+				})
+			}
 			return hookResponse
 		}
 
-		if hookResponse.Mutated && target.MutateDisallowed {
-			if hookResponse.Reason != "" {
-				hookResponse.Reason += "; "
-			}
-
-			hookResponse.Reason += "mutation not allowed by hook configuration, implicit rejection"
-			hookResponse.Accept = false
-			hookResponse.Mutated = false
-		}
-
 		if auditLog != nil {
-			status := "ok"
-			if !hookResponse.Accept {
+			status := ""
+			switch hookResponse.NormalizedDecision {
+			case filtercontract.DecisionAccept:
+				status = "ok"
+			case filtercontract.DecisionReject:
 				status = "rejected"
-			} else if hookResponse.Mutated {
+			case filtercontract.DecisionMutate:
 				status = "mutated"
 			}
 			auditLog.WebhookStatuses = append(auditLog.WebhookStatuses, auditlogs.MCPWebhookStatus{
@@ -871,6 +888,81 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 	})
 
 	return hookResponse.Message, errors.Join(errs...)
+}
+
+func invokeMCPFilterHooks(
+	ctx context.Context,
+	r HookRunner,
+	hooks Hooks,
+	in *SessionMessageHook,
+	name string,
+	params map[string]string,
+	direction string,
+	identifier string,
+	filterContext filtercontract.Context,
+	callbacks ...HookResponseCallback[SessionMessageHook],
+) (SessionMessageHook, error) {
+	var (
+		current = in
+		matched bool
+		errs    []error
+	)
+	for _, mapping := range hooks {
+		if !mapping.Matches(name, params) {
+			continue
+		}
+		for _, target := range mapping.Targets {
+			matched = true
+			var (
+				out       SessionMessageHook
+				hasOutput bool
+				err       error
+			)
+			switch target.ContractVersion {
+			case filtercontract.ContractVersionV1:
+				capabilities := filtercontract.Capabilities{CanReject: true, CanMutate: !target.MutateDisallowed}
+				request, requestErr := newMCPFilterRequest(current.Message, direction, name, identifier, filterContext, capabilities)
+				if requestErr != nil {
+					err = requestErr
+				} else {
+					var response filtercontract.Response
+					hasOutput, err = r.RunHook(ctx, &request, &response, target.Target)
+					if err == nil && !hasOutput {
+						err = errors.New("v1 Filter returned no structured response")
+					} else if err == nil {
+						out, err = normalizeV1FilterResponse(response, current.Message, identifier, capabilities)
+					}
+				}
+			case filtercontract.ContractVersionLegacyMCP:
+				hasOutput, err = r.RunHook(ctx, current, &out, target.Target)
+				if err == nil && hasOutput {
+					out, err = normalizeLegacyFilterResponse(out, current.Message, target.MutateDisallowed)
+				}
+			default:
+				err = fmt.Errorf("unsupported Filter contract version %q", target.ContractVersion)
+			}
+
+			if hasOutput || err != nil {
+				if err != nil {
+					out = *current
+				}
+				for _, cb := range callbacks {
+					out = cb(mapping, target, out, err)
+				}
+			}
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to run hook %s: %w", mapping.String(), err))
+				continue
+			}
+			if hasOutput {
+				current = &out
+			}
+		}
+	}
+	if !matched {
+		return *in, errors.Join(errs...)
+	}
+	return *current, errors.Join(errs...)
 }
 
 func addHookMutationsMeta(resp *Message) error {

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -794,7 +794,7 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 	}
 
 	filterContext := filtercontract.Context{}
-	if sessionID := s.ID(); sessionID != "" {
+	if sessionID := s.Root().ID(); sessionID != "" {
 		filterContext.Trace = &filtercontract.TraceContext{SessionID: sessionID}
 	}
 	if server.Name != "" || server.ShortName != "" {
@@ -930,7 +930,7 @@ func invokeMCPFilterHooks(
 					if err == nil && !hasOutput {
 						err = errors.New("v1 Filter returned no structured response")
 					} else if err == nil {
-						out, err = normalizeV1FilterResponse(response, current.Message, identifier, capabilities)
+						out, err = normalizeV1FilterResponse(response, current.Message, direction, identifier, capabilities)
 					}
 				}
 			case filtercontract.ContractVersionLegacyMCP:

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -926,7 +926,7 @@ func invokeMCPFilterHooks(
 					err = requestErr
 				} else {
 					var response filtercontract.Response
-					hasOutput, err = r.RunHook(ctx, &request, &response, target.Target)
+					hasOutput, err = r.RunHook(ctx, &filtercontract.ToolRequest{Request: request}, &response, target.Target)
 					if err == nil && !hasOutput {
 						err = errors.New("v1 Filter returned no structured response")
 					} else if err == nil {

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -851,11 +851,13 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 
 		// Use the hook response message if set, otherwise use the last value we have
 		if hookResponse.Mutated && hookResponse.Message != nil {
-			if string(hookResponse.Message.Result) == "null" {
-				hookResponse.Message.Result = nil
-			}
-			if string(hookResponse.Message.Params) == "null" {
-				hookResponse.Message.Params = nil
+			if target.ContractVersion == filtercontract.ContractVersionLegacyMCP {
+				if string(hookResponse.Message.Result) == "null" {
+					hookResponse.Message.Result = nil
+				}
+				if string(hookResponse.Message.Params) == "null" {
+					hookResponse.Message.Params = nil
+				}
 			}
 
 			if auditLog != nil {

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"slices"
+	"strings"
 	"testing"
 
+	filtercontract "github.com/obot-platform/nanobot/pkg/filter"
 	"github.com/obot-platform/nanobot/pkg/mcp/auditlogs"
 )
 
@@ -21,6 +23,12 @@ func (r staticHookRunner) RunHook(_ context.Context, _, out any, _ string) (bool
 type sequenceHookRunner struct {
 	responses []SessionMessageHook
 	next      int
+}
+
+type hookRunnerFunc func(context.Context, any, any, string) (bool, error)
+
+func (f hookRunnerFunc) RunHook(ctx context.Context, in, out any, target string) (bool, error) {
+	return f(ctx, in, out, target)
 }
 
 type recordingDeleteSessionCloser struct {
@@ -353,6 +361,246 @@ func TestCallAllHooksAccumulatesMutationReasons(t *testing.T) {
 	}
 
 	assertHookMutation(t, msg.HookMutations, "request", "first mutation", "second mutation")
+}
+
+func TestCallAllHooksUsesV1EnvelopeOnlyWhenMarked(t *testing.T) {
+	var calls int
+	runner := hookRunnerFunc(func(_ context.Context, in, out any, target string) (bool, error) {
+		calls++
+		if target != "filter/tool" {
+			t.Fatalf("target = %q", target)
+		}
+		request, ok := in.(*filtercontract.Request)
+		if !ok {
+			t.Fatalf("input type = %T, want *filter.Request", in)
+		}
+		if request.APIVersion != filtercontract.APIVersionV1 || request.Source != filtercontract.SourceMCP {
+			t.Fatalf("unexpected envelope: %#v", request)
+		}
+		if request.Event.Method != "tools/call" || request.Event.Identifier != "search" || request.Event.Phase != filtercontract.PhaseRequest {
+			t.Fatalf("unexpected event: %#v", request.Event)
+		}
+		if !request.Capabilities.CanReject || !request.Capabilities.CanMutate {
+			t.Fatalf("unexpected capabilities: %#v", request.Capabilities)
+		}
+		if request.Context.MCP == nil || request.Context.MCP.ServerName != "server-id" || request.Context.MCP.ServerShortName != "Search Server" {
+			t.Fatalf("unexpected MCP context: %#v", request.Context.MCP)
+		}
+		response, ok := out.(*filtercontract.Response)
+		if !ok {
+			t.Fatalf("output type = %T, want *filter.Response", out)
+		}
+		*response = filtercontract.Response{Decision: filtercontract.DecisionAccept, Reason: "allowed"}
+		return true, nil
+	})
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{
+		HookRunner: runner,
+		hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+			Target:          "filter/tool",
+			ContractVersion: filtercontract.ContractVersionV1,
+		}}}},
+	}
+	original := &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"search","arguments":{"query":"test"}}`),
+	}
+	ctx := WithMCPServerConfig(WithAuditLog(t.Context(), auditLog), Server{Name: "server-id", ShortName: "Search Server"})
+	message, err := s.callAllHooks(ctx, original, "request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if message != original {
+		t.Fatal("acceptance replaced the original message")
+	}
+	if len(auditLog.WebhookStatuses) != 1 || auditLog.WebhookStatuses[0].Status != "ok" || auditLog.WebhookStatuses[0].Message != "allowed" {
+		t.Fatalf("unexpected statuses: %#v", auditLog.WebhookStatuses)
+	}
+}
+
+func TestCallAllHooksV1MutationChainingAndAggregateRejection(t *testing.T) {
+	mutated := &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"search","arguments":{"query":"redacted"}}`),
+	}
+	mutatedPayload, err := json.Marshal(mutated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls []string
+	runner := hookRunnerFunc(func(_ context.Context, in, out any, target string) (bool, error) {
+		request := in.(*filtercontract.Request)
+		response := out.(*filtercontract.Response)
+		calls = append(calls, target)
+		switch target {
+		case "first/filter":
+			*response = filtercontract.Response{Decision: filtercontract.DecisionMutate, Reason: "redacted", Payload: mutatedPayload}
+		case "second/filter":
+			if !strings.Contains(string(request.Payload), `"query":"redacted"`) {
+				t.Fatalf("second Filter did not receive mutation: %s", request.Payload)
+			}
+			*response = filtercontract.Response{Decision: filtercontract.DecisionReject, Reason: "blocked"}
+		case "third/filter":
+			if !strings.Contains(string(request.Payload), `"query":"redacted"`) {
+				t.Fatalf("third Filter did not receive effective payload: %s", request.Payload)
+			}
+			*response = filtercontract.Response{Decision: filtercontract.DecisionAccept}
+		}
+		return true, nil
+	})
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{
+		HookRunner: runner,
+		hooks: Hooks{{
+			Name: "tools/call",
+			Targets: []HookTarget{
+				{Target: "first/filter", ContractVersion: filtercontract.ContractVersionV1},
+				{Target: "second/filter", ContractVersion: filtercontract.ContractVersionV1},
+				{Target: "third/filter", ContractVersion: filtercontract.ContractVersionV1},
+			},
+		}},
+	}
+	original := &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"search","arguments":{"query":"original"}}`),
+	}
+	message, err := s.callAllHooks(WithAuditLog(t.Context(), auditLog), original, "request")
+	if err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("error = %v, want aggregate rejection", err)
+	}
+	if !slices.Equal(calls, []string{"first/filter", "second/filter", "third/filter"}) {
+		t.Fatalf("calls = %v", calls)
+	}
+	if !strings.Contains(string(message.Params), `"query":"redacted"`) {
+		t.Fatalf("effective message = %s", message.Params)
+	}
+	if got := []string{auditLog.WebhookStatuses[0].Status, auditLog.WebhookStatuses[1].Status, auditLog.WebhookStatuses[2].Status}; !slices.Equal(got, []string{"mutated", "rejected", "ok"}) {
+		t.Fatalf("statuses = %v", got)
+	}
+}
+
+func TestCallAllHooksRejectsForbiddenV1Mutation(t *testing.T) {
+	original := &Message{JSONRPC: "2.0", ID: float64(1), Method: "tools/call", Params: json.RawMessage(`{"name":"search"}`)}
+	payload, err := json.Marshal(&Message{JSONRPC: "2.0", ID: float64(1), Method: "tools/call", Params: json.RawMessage(`{"name":"search","arguments":{"query":"changed"}}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := hookRunnerFunc(func(_ context.Context, in, out any, _ string) (bool, error) {
+		request := in.(*filtercontract.Request)
+		if request.Capabilities.CanMutate {
+			t.Fatal("mutation capability should be false")
+		}
+		*(out.(*filtercontract.Response)) = filtercontract.Response{Decision: filtercontract.DecisionMutate, Reason: "redact", Payload: payload}
+		return true, nil
+	})
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+		Target: "filter/tool", MutateDisallowed: true, ContractVersion: filtercontract.ContractVersionV1,
+	}}}}}
+	message, err := s.callAllHooks(WithAuditLog(t.Context(), auditLog), original, "request")
+	if err == nil || !strings.Contains(err.Error(), mutationDisallowedReason) {
+		t.Fatalf("error = %v", err)
+	}
+	if message != original || original.HookMutations != nil {
+		t.Fatal("forbidden mutation changed the message")
+	}
+	if len(auditLog.WebhookStatuses) != 1 || auditLog.WebhookStatuses[0].Status != "rejected" {
+		t.Fatalf("statuses = %#v", auditLog.WebhookStatuses)
+	}
+}
+
+func TestCallAllHooksRejectsInvalidV1DecisionWithoutRetry(t *testing.T) {
+	var calls int
+	runner := hookRunnerFunc(func(_ context.Context, _, out any, _ string) (bool, error) {
+		calls++
+		*(out.(*filtercontract.Response)) = filtercontract.Response{Decision: "maybe"}
+		return true, nil
+	})
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+		Target: "filter/tool", ContractVersion: filtercontract.ContractVersionV1,
+	}}}}}
+	message := &Message{JSONRPC: "2.0", ID: float64(1), Method: "tools/call", Params: json.RawMessage(`{"name":"search"}`)}
+	_, err := s.callAllHooks(WithAuditLog(t.Context(), auditLog), message, "request")
+	if err == nil || !strings.Contains(err.Error(), `unknown filter decision "maybe"`) {
+		t.Fatalf("error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want no fallback or retry", calls)
+	}
+	if len(auditLog.WebhookStatuses) != 1 || auditLog.WebhookStatuses[0].Status != "failed" {
+		t.Fatalf("statuses = %#v", auditLog.WebhookStatuses)
+	}
+}
+
+func TestCallAllHooksRejectsInvalidV1MutationPayload(t *testing.T) {
+	runner := hookRunnerFunc(func(_ context.Context, _, out any, _ string) (bool, error) {
+		*(out.(*filtercontract.Response)) = filtercontract.Response{
+			Decision: filtercontract.DecisionMutate,
+			Payload:  json.RawMessage(`"not-an-mcp-message"`),
+		}
+		return true, nil
+	})
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+		Target: "filter/tool", ContractVersion: filtercontract.ContractVersionV1,
+	}}}}}
+	message := &Message{JSONRPC: "2.0", ID: float64(1), Method: "tools/call", Params: json.RawMessage(`{"name":"search"}`)}
+	_, err := s.callAllHooks(WithAuditLog(t.Context(), auditLog), message, "request")
+	if err == nil || !strings.Contains(err.Error(), "mutation payload must be an MCP message object") {
+		t.Fatalf("error = %v", err)
+	}
+	if len(auditLog.WebhookStatuses) != 1 || auditLog.WebhookStatuses[0].Status != "failed" {
+		t.Fatalf("statuses = %#v", auditLog.WebhookStatuses)
+	}
+}
+
+func TestCallAllHooksRejectsV1MutationOfMessageIdentity(t *testing.T) {
+	mutated, err := json.Marshal(&Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"different-tool"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := hookRunnerFunc(func(_ context.Context, _, out any, _ string) (bool, error) {
+		*(out.(*filtercontract.Response)) = filtercontract.Response{Decision: filtercontract.DecisionMutate, Payload: mutated}
+		return true, nil
+	})
+	s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+		Target: "filter/tool", ContractVersion: filtercontract.ContractVersionV1,
+	}}}}}
+	message := &Message{JSONRPC: "2.0", ID: float64(1), Method: "tools/call", Params: json.RawMessage(`{"name":"search"}`)}
+	_, err = s.callAllHooks(t.Context(), message, "request")
+	if err == nil || !strings.Contains(err.Error(), "mutation changed immutable MCP message identity") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCallAllHooksUnmarkedTargetUsesLegacyContract(t *testing.T) {
+	runner := hookRunnerFunc(func(_ context.Context, in, out any, _ string) (bool, error) {
+		if _, ok := in.(*SessionMessageHook); !ok {
+			t.Fatalf("input type = %T, want legacy *SessionMessageHook", in)
+		}
+		*(out.(*SessionMessageHook)) = SessionMessageHook{Accept: true}
+		return true, nil
+	})
+	s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{Target: "filter/tool"}}}}}
+	message := &Message{JSONRPC: "2.0", ID: float64(1), Method: "tools/call", Params: json.RawMessage(`{"name":"search"}`)}
+	if _, err := s.callAllHooks(t.Context(), message, "request"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func assertJSONEqual(t *testing.T, actual json.RawMessage, expected any) {

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -398,6 +398,9 @@ func TestCallAllHooksUsesWrappedV1EnvelopeOnlyWhenMarked(t *testing.T) {
 		if request.Context.MCP == nil || request.Context.MCP.ServerName != "server-id" || request.Context.MCP.ServerShortName != "Search Server" {
 			t.Fatalf("unexpected MCP context: %#v", request.Context.MCP)
 		}
+		if request.Context.Trace == nil || request.Context.Trace.SessionID != "test-session" {
+			t.Fatalf("unexpected trace context: %#v", request.Context.Trace)
+		}
 		response, ok := out.(*filtercontract.Response)
 		if !ok {
 			t.Fatalf("output type = %T, want *filter.Response", out)
@@ -408,6 +411,7 @@ func TestCallAllHooksUsesWrappedV1EnvelopeOnlyWhenMarked(t *testing.T) {
 	auditLog := &auditlogs.MCPAuditLog{}
 	s := &Session{
 		HookRunner: runner,
+		Parent:     &Session{wire: &closeCallbackWire{}},
 		hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
 			Target:          "filter/tool",
 			ContractVersion: filtercontract.ContractVersionV1,
@@ -496,6 +500,9 @@ func TestCallAllHooksV1MutationChainingAndAggregateRejection(t *testing.T) {
 	if !strings.Contains(string(message.Params), `"query":"redacted"`) {
 		t.Fatalf("effective message = %s", message.Params)
 	}
+	if len(auditLog.WebhookStatuses) != 3 {
+		t.Fatalf("statuses = %#v, want 3", auditLog.WebhookStatuses)
+	}
 	if got := []string{auditLog.WebhookStatuses[0].Status, auditLog.WebhookStatuses[1].Status, auditLog.WebhookStatuses[2].Status}; !slices.Equal(got, []string{"mutated", "rejected", "ok"}) {
 		t.Fatalf("statuses = %v", got)
 	}
@@ -575,6 +582,66 @@ func TestCallAllHooksRejectsInvalidV1MutationPayload(t *testing.T) {
 	}
 	if len(auditLog.WebhookStatuses) != 1 || auditLog.WebhookStatuses[0].Status != "failed" {
 		t.Fatalf("statuses = %#v", auditLog.WebhookStatuses)
+	}
+}
+
+func TestCallAllHooksRejectsInvalidV1MutationShape(t *testing.T) {
+	tests := []struct {
+		name      string
+		direction string
+		message   *Message
+		wantError string
+	}{
+		{
+			name:      "request with result",
+			direction: "request",
+			message: &Message{
+				JSONRPC: "2.0",
+				ID:      float64(1),
+				Method:  "tools/call",
+				Params:  json.RawMessage(`{"name":"search"}`),
+				Result:  json.RawMessage(`{}`),
+			},
+			wantError: "request mutation must not contain result or error",
+		},
+		{
+			name:      "response with result and error",
+			direction: "response",
+			message: &Message{
+				JSONRPC: "2.0",
+				ID:      float64(1),
+				Method:  "tools/call",
+				Params:  json.RawMessage(`{"name":"search"}`),
+				Result:  json.RawMessage(`{}`),
+				Error:   NewRPCError(-32603, "failed"),
+			},
+			wantError: "response mutation must contain exactly one of result or error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := json.Marshal(tt.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			runner := hookRunnerFunc(func(_ context.Context, _, out any, _ string) (bool, error) {
+				*(out.(*filtercontract.Response)) = filtercontract.Response{Decision: filtercontract.DecisionMutate, Payload: payload}
+				return true, nil
+			})
+			s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+				Target: "filter/tool", ContractVersion: filtercontract.ContractVersionV1,
+			}}}}}
+			_, err = s.callAllHooks(t.Context(), &Message{
+				JSONRPC: "2.0",
+				ID:      float64(1),
+				Method:  "tools/call",
+				Params:  json.RawMessage(`{"name":"search"}`),
+			}, tt.direction)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want %q", err, tt.wantError)
+			}
+		})
 	}
 }
 

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -645,6 +645,49 @@ func TestCallAllHooksRejectsInvalidV1MutationShape(t *testing.T) {
 	}
 }
 
+func TestCallAllHooksPreservesV1NullResultMutation(t *testing.T) {
+	mutated, err := json.Marshal(&Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"search"}`),
+		Result:  json.RawMessage(`null`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := hookRunnerFunc(func(_ context.Context, _, out any, _ string) (bool, error) {
+		*(out.(*filtercontract.Response)) = filtercontract.Response{
+			Decision: filtercontract.DecisionMutate,
+			Payload:  mutated,
+		}
+		return true, nil
+	})
+	s := &Session{HookRunner: runner, hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{
+		Target: "filter/tool", ContractVersion: filtercontract.ContractVersionV1,
+	}}}}}
+	message, err := s.callAllHooks(t.Context(), &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"search"}`),
+		Result:  json.RawMessage(`{"content":[]}`),
+	}, "response")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(message.Result) != "null" {
+		t.Fatalf("result = %s, want explicit null", message.Result)
+	}
+	var result any
+	if err := s.marshalResponse(*message, &result); err != nil {
+		t.Fatalf("explicit null result failed to marshal: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil JSON value", result)
+	}
+}
+
 func TestCallAllHooksRejectsV1MutationOfMessageIdentity(t *testing.T) {
 	mutated, err := json.Marshal(&Message{
 		JSONRPC: "2.0",

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -363,17 +363,29 @@ func TestCallAllHooksAccumulatesMutationReasons(t *testing.T) {
 	assertHookMutation(t, msg.HookMutations, "request", "first mutation", "second mutation")
 }
 
-func TestCallAllHooksUsesV1EnvelopeOnlyWhenMarked(t *testing.T) {
+func TestCallAllHooksUsesWrappedV1EnvelopeOnlyWhenMarked(t *testing.T) {
 	var calls int
 	runner := hookRunnerFunc(func(_ context.Context, in, out any, target string) (bool, error) {
 		calls++
 		if target != "filter/tool" {
 			t.Fatalf("target = %q", target)
 		}
-		request, ok := in.(*filtercontract.Request)
+		toolRequest, ok := in.(*filtercontract.ToolRequest)
 		if !ok {
-			t.Fatalf("input type = %T, want *filter.Request", in)
+			t.Fatalf("input type = %T, want *filter.ToolRequest", in)
 		}
+		inputJSON, err := json.Marshal(toolRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var inputFields map[string]json.RawMessage
+		if err := json.Unmarshal(inputJSON, &inputFields); err != nil {
+			t.Fatal(err)
+		}
+		if len(inputFields) != 1 || len(inputFields["request"]) == 0 {
+			t.Fatalf("v1 tool arguments = %s, want only a request wrapper", inputJSON)
+		}
+		request := &toolRequest.Request
 		if request.APIVersion != filtercontract.APIVersionV1 || request.Source != filtercontract.SourceMCP {
 			t.Fatalf("unexpected envelope: %#v", request)
 		}
@@ -436,7 +448,8 @@ func TestCallAllHooksV1MutationChainingAndAggregateRejection(t *testing.T) {
 	}
 	var calls []string
 	runner := hookRunnerFunc(func(_ context.Context, in, out any, target string) (bool, error) {
-		request := in.(*filtercontract.Request)
+		toolRequest := in.(*filtercontract.ToolRequest)
+		request := &toolRequest.Request
 		response := out.(*filtercontract.Response)
 		calls = append(calls, target)
 		switch target {
@@ -495,7 +508,8 @@ func TestCallAllHooksRejectsForbiddenV1Mutation(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := hookRunnerFunc(func(_ context.Context, in, out any, _ string) (bool, error) {
-		request := in.(*filtercontract.Request)
+		toolRequest := in.(*filtercontract.ToolRequest)
+		request := &toolRequest.Request
 		if request.Capabilities.CanMutate {
 			t.Fatal("mutation capability should be false")
 		}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/obot-platform/mcp-oauth-proxy/pkg/providers"
+	filtercontract "github.com/obot-platform/nanobot/pkg/filter"
 )
 
 type User providers.UserInfo
@@ -497,10 +498,11 @@ type SetLogLevelRequest struct {
 type SetLogLevelResult struct{}
 
 type SessionMessageHook struct {
-	Accept  bool     `json:"accept"`
-	Mutated bool     `json:"mutated"`
-	Message *Message `json:"message"`
-	Reason  string   `json:"reason"`
+	Accept             bool                    `json:"accept"`
+	Mutated            bool                    `json:"mutated"`
+	Message            *Message                `json:"message"`
+	Reason             string                  `json:"reason"`
+	NormalizedDecision filtercontract.Decision `json:"-"`
 }
 
 type CancelledNotification struct {


### PR DESCRIPTION
part of https://github.com/obot-platform/obot/issues/7538

This introduces the new shape/API contract for hooks into Nanobot. Nanobot will continue to also support the legacy MCP-only hook shape.

Merging this does nothing on its own until we cut a new Nanobot release or bump the dependency in Obot, so it is safe.