### PR TITLE
feat(llm): add built-in orcarouter LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ my-config/
 
 **LLM Providers**
 
-`openai` and `anthropic` are built-in providers — set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` and they work with no additional config. Use the `{provider}/{model}` format in the `model` field to select a provider.
+`openai`, `anthropic`, and `orcarouter` are built-in providers — set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `ORCAROUTER_API_KEY` and they work with no additional config. Use the `{provider}/{model}` format in the `model` field to select a provider. For OrcaRouter, model ids carry their own provider prefix, so the model field uses the `orcarouter/<provider>/<model>` format, e.g. `orcarouter/openai/gpt-4o`.
 
 Additional providers (Azure, Bedrock, Ollama, etc.) can be configured in `nanobot.yaml` under `llmProviders`. 
 
@@ -139,6 +139,13 @@ llmProviders:
     dialect: AnthropicMessages
     apiKey: ${ANTHROPIC_API_KEY}
     baseURL: ${ANTHROPIC_BASE_URL}  # optional, default: https://api.anthropic.com/v1
+
+  # OrcaRouter: 200+ models behind one OpenAI-compatible endpoint. Model ids
+  # keep their own provider prefix, e.g. "orcarouter/openai/gpt-4o".
+  orcarouter:
+    dialect: OpenAIResponses
+    apiKey: ${ORCAROUTER_API_KEY}
+    baseURL: https://api.orcarouter.ai/v1
 
   # Custom providers pointing at any compatible endpoint
   azureOpenAI:

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -175,6 +175,17 @@ func (n *Nanobot) llmConfig() llm.Config {
 				APIKey:  "${ANTHROPIC_API_KEY}",
 				BaseURL: "${ANTHROPIC_BASE_URL}",
 			},
+			// OrcaRouter is an OpenAI-compatible router that exposes 200+ models
+			// (e.g. openai/gpt-4o, anthropic/claude-sonnet-4.6) behind one endpoint.
+			// Its model ids carry their own provider prefix, so reference them as
+			// "orcarouter/<provider>/<model>", e.g. "orcarouter/openai/gpt-4o".
+			"orcarouter": {
+				Dialect: types.DialectOpenAIResponses,
+				APIKey:  "${ORCAROUTER_API_KEY}",
+				// Hardcoded: unlike OPENAI_BASE_URL there is no ORCAROUTER_BASE_URL
+				// default, and an empty BaseURL would fall back to api.openai.com/v1.
+				BaseURL: "https://api.orcarouter.ai/v1",
+			},
 		},
 	}
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/obot-platform/nanobot/pkg/config"
+	"github.com/obot-platform/nanobot/pkg/types"
 )
 
 func TestNanobotConfigPathsDefault(t *testing.T) {
@@ -14,6 +15,36 @@ func TestNanobotConfigPathsDefault(t *testing.T) {
 	paths := n.ConfigPaths()
 	if len(paths) != 1 || paths[0] != config.DefaultConfigPath {
 		t.Fatalf("expected default config path [.nanobot/], got %v", paths)
+	}
+}
+
+func TestNanobotLLMConfigBuiltinOrcaRouter(t *testing.T) {
+	n := &Nanobot{}
+
+	cfg := n.llmConfig()
+	orcarouter, ok := cfg.LLMProviders["orcarouter"]
+	if !ok {
+		t.Fatalf("expected built-in orcarouter provider, got %v", cfg.LLMProviders)
+	}
+	if orcarouter.Dialect != types.DialectOpenAIResponses {
+		t.Errorf("orcarouter dialect: got %q, want %q", orcarouter.Dialect, types.DialectOpenAIResponses)
+	}
+	if orcarouter.APIKey != "${ORCAROUTER_API_KEY}" {
+		t.Errorf("orcarouter apiKey: got %q, want %q", orcarouter.APIKey, "${ORCAROUTER_API_KEY}")
+	}
+	if orcarouter.BaseURL != "https://api.orcarouter.ai/v1" {
+		t.Errorf("orcarouter baseURL: got %q, want %q", orcarouter.BaseURL, "https://api.orcarouter.ai/v1")
+	}
+}
+
+func TestNanobotLLMConfigBuiltinProviders(t *testing.T) {
+	n := &Nanobot{}
+
+	cfg := n.llmConfig()
+	for _, name := range []string{"openai", "anthropic", "orcarouter"} {
+		if _, ok := cfg.LLMProviders[name]; !ok {
+			t.Errorf("expected built-in provider %q", name)
+		}
 	}
 }
 

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -13,9 +13,10 @@ func TestResolveProvider(t *testing.T) {
 		DefaultModel:     "openai/gpt-4.1",
 		DefaultMiniModel: "anthropic/claude-haiku-4-5",
 		LLMProviders: map[string]LLMProviderConfig{
-			"openai":    {Dialect: types.DialectOpenAIResponses},
-			"anthropic": {Dialect: types.DialectAnthropicMessages},
-			"azure":     {Dialect: types.DialectOpenAIResponses},
+			"openai":     {Dialect: types.DialectOpenAIResponses},
+			"anthropic":  {Dialect: types.DialectAnthropicMessages},
+			"azure":      {Dialect: types.DialectOpenAIResponses},
+			"orcarouter": {Dialect: types.DialectOpenAIResponses},
 		},
 	}
 
@@ -34,6 +35,8 @@ func TestResolveProvider(t *testing.T) {
 		{"openai prefix", "openai/gpt-4o", "gpt-4o", "openai"},
 		{"anthropic prefix", "anthropic/claude-3-7-sonnet-latest", "claude-3-7-sonnet-latest", "anthropic"},
 		{"azure prefix", "azure/gpt-4o", "gpt-4o", "azure"},
+		{"orcarouter prefix", "orcarouter/openai/gpt-4o", "openai/gpt-4o", "orcarouter"},
+		{"orcarouter anthropic model", "orcarouter/anthropic/claude-sonnet-4.6", "anthropic/claude-sonnet-4.6", "orcarouter"},
 		{"unknown provider prefix", "vertex/gemini-pro", "gemini-pro", "vertex"},
 
 		// Default fallbacks (no prefix)


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a built-in LLM provider in
Nanobot, alongside the existing `openai` and `anthropic` built-ins. OrcaRouter
is an OpenAI-compatible model routing gateway that exposes 200+ models from
OpenAI, Anthropic, Google, DeepSeek and others behind a single endpoint and API
key, with gateway-level security controls for AI agents.

Setting `ORCAROUTER_API_KEY` is enough to start using it:

```yaml
agents:
  main:
    model: orcarouter/openai/gpt-4o
```

Because OrcaRouter model ids carry their own provider prefix, the `model` field
uses the `orcarouter/<provider>/<model>` format (e.g.
`orcarouter/openai/gpt-4o`, `orcarouter/anthropic/claude-sonnet-4.6`,
`orcarouter/deepseek/deepseek-v4-flash`).

I'm an engineer on the OrcaRouter team.

## Motivation and Context

`pkg/cli/root.go`'s `llmConfig()` already ships built-in `openai` and
`anthropic` providers for zero-config use. Adding `orcarouter` as a named
built-in gives users the same one-env-var experience for the OrcaRouter
gateway. The base URL is pinned to `https://api.orcarouter.ai/v1` so an unset
env var can never silently fall back to `api.openai.com/v1`.

### Additional Changes
- [ ] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables
  - New built-in provider `orcarouter` reading `ORCAROUTER_API_KEY`
    (documented in `README.md`)

## How did you test it?

- `go build ./...` and `gofmt` are clean.
- `go test ./pkg/llm/... ./pkg/cli/...` passes, including new tests
  (`TestNanobotLLMConfigBuiltinOrcaRouter`, `TestNanobotLLMConfigBuiltinProviders`,
  and `orcarouter` resolve cases in `TestResolveProvider`).
- Live API: `llm.Client.Complete` with the built-in provider shape
  (`model: orcarouter/deepseek/deepseek-v4-flash`) returns a valid completion
  (HTTP 200) against the real OrcaRouter API.
- Note: `go test ./...` has a pre-existing Windows-only failure in
  `pkg/session` (`TestDeleteSessionsUpdatedBefore`: SQLite temp-dir cleanup
  file lock). It reproduces on a clean checkout and is unrelated to this change.
